### PR TITLE
Mark message-ix arch-specific files as broken

### DIFF
--- a/pkgs/message-ix.txt
+++ b/pkgs/message-ix.txt
@@ -1,0 +1,6 @@
+linux-64/message-ix-1.0.0-2.tar.bz2
+linux-64/message-ix-1.0.0-3.tar.bz2
+osx-64/message-ix-1.0.0-2.tar.bz2
+osx-64/message-ix-1.0.0-3.tar.bz2
+win-64/message-ix-1.0.0-2.tar.bz2
+win-64/message-ix-1.0.0-3.tar.bz2


### PR DESCRIPTION
Users of [message_ix](https://github.com/iiasa/message_ix) report, and we have confirmed, that the presence of these arch-specific files makes `conda` want to install them, rather than the latest version, which is noarch. 

After wrestling with `conda install`, I have been unable to devise a combination of options/configuration/channel priority that makes the solver follow user intent. Since these versions are old and no longer supported, I am hoping that removing them from the repository will prevent the solver from being confused.

Checklist:
* [x] Added a link to the relevant issue in the PR description. (Above.)
* [x] Pinged the team for the package.