### PR TITLE
ENH mark pytest 6 rc1 as broken

### DIFF
--- a/broken/pytest6.txt
+++ b/broken/pytest6.txt
@@ -1,0 +1,37 @@
+417.8 kB	 | linux-64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2	 1 day and 11 hours ago	cf-staging	1229	main
+edit labels
+	conda	438.3 kB	 | win-64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2	 1 day and 11 hours ago	cf-staging	434	main
+edit labels
+	conda	414.5 kB	 | linux-aarch64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2	 1 day and 11 hours ago	cf-staging	14	main
+edit labels
+	conda	414.6 kB	 | linux-64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2	 1 day and 11 hours ago	cf-staging	1306	main
+edit labels
+	conda	420.9 kB	 | linux-64/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2	 1 day and 11 hours ago	cf-staging	27	main
+edit labels
+	conda	415.6 kB	 | linux-64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2	 1 day and 11 hours ago	cf-staging	2056	main
+edit labels
+	conda	414.9 kB	 | linux-ppc64le/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2	 1 day and 11 hours ago	cf-staging	3	main
+edit labels
+	conda	420.7 kB	 | linux-aarch64/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2	 1 day and 11 hours ago	cf-staging	2	main
+edit labels
+	conda	443.9 kB	 | win-64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2	 1 day and 11 hours ago	cf-staging	213	main
+edit labels
+	conda	417.5 kB	 | linux-aarch64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2	 1 day and 11 hours ago	cf-staging	3	main
+edit labels
+	conda	437.6 kB	 | win-64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2	 1 day and 11 hours ago	cf-staging	284	main
+edit labels
+	conda	417.6 kB	 | linux-ppc64le/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2	 1 day and 11 hours ago	cf-staging	4	main
+edit labels
+	conda	414.7 kB	 | linux-ppc64le/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2	 1 day and 11 hours ago	cf-staging	3	main
+edit labels
+	conda	415.0 kB	 | linux-aarch64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2	 1 day and 11 hours ago	cf-staging	2	main
+edit labels
+	conda	420.9 kB	 | linux-ppc64le/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2	 1 day and 11 hours ago	cf-staging	2	main
+edit labels
+	conda	414.3 kB	 | osx-64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2	 1 day and 11 hours ago	cf-staging	112	main
+edit labels
+	conda	417.2 kB	 | osx-64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2	 1 day and 11 hours ago	cf-staging	67	main
+edit labels
+	conda	420.7 kB	 | osx-64/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2	 1 day and 11 hours ago	cf-staging	8	main
+edit labels
+	conda	414.0 kB	 | osx-64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2

--- a/broken/pytest6.txt
+++ b/broken/pytest6.txt
@@ -1,37 +1,19 @@
-417.8 kB	 | linux-64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2	 1 day and 11 hours ago	cf-staging	1229	main
-edit labels
-	conda	438.3 kB	 | win-64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2	 1 day and 11 hours ago	cf-staging	434	main
-edit labels
-	conda	414.5 kB	 | linux-aarch64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2	 1 day and 11 hours ago	cf-staging	14	main
-edit labels
-	conda	414.6 kB	 | linux-64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2	 1 day and 11 hours ago	cf-staging	1306	main
-edit labels
-	conda	420.9 kB	 | linux-64/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2	 1 day and 11 hours ago	cf-staging	27	main
-edit labels
-	conda	415.6 kB	 | linux-64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2	 1 day and 11 hours ago	cf-staging	2056	main
-edit labels
-	conda	414.9 kB	 | linux-ppc64le/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2	 1 day and 11 hours ago	cf-staging	3	main
-edit labels
-	conda	420.7 kB	 | linux-aarch64/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2	 1 day and 11 hours ago	cf-staging	2	main
-edit labels
-	conda	443.9 kB	 | win-64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2	 1 day and 11 hours ago	cf-staging	213	main
-edit labels
-	conda	417.5 kB	 | linux-aarch64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2	 1 day and 11 hours ago	cf-staging	3	main
-edit labels
-	conda	437.6 kB	 | win-64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2	 1 day and 11 hours ago	cf-staging	284	main
-edit labels
-	conda	417.6 kB	 | linux-ppc64le/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2	 1 day and 11 hours ago	cf-staging	4	main
-edit labels
-	conda	414.7 kB	 | linux-ppc64le/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2	 1 day and 11 hours ago	cf-staging	3	main
-edit labels
-	conda	415.0 kB	 | linux-aarch64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2	 1 day and 11 hours ago	cf-staging	2	main
-edit labels
-	conda	420.9 kB	 | linux-ppc64le/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2	 1 day and 11 hours ago	cf-staging	2	main
-edit labels
-	conda	414.3 kB	 | osx-64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2	 1 day and 11 hours ago	cf-staging	112	main
-edit labels
-	conda	417.2 kB	 | osx-64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2	 1 day and 11 hours ago	cf-staging	67	main
-edit labels
-	conda	420.7 kB	 | osx-64/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2	 1 day and 11 hours ago	cf-staging	8	main
-edit labels
-	conda	414.0 kB	 | osx-64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2
+linux-64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2
+win-64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2
+linux-aarch64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2
+linux-64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2
+linux-64/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2
+linux-64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2
+linux-ppc64le/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2
+linux-aarch64/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2
+win-64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2
+linux-aarch64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2
+win-64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2
+linux-ppc64le/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2
+linux-ppc64le/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2
+linux-aarch64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2
+linux-ppc64le/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2
+osx-64/pytest-6.0.0rc1-py36h9f0ad1d_0.tar.bz2
+osx-64/pytest-6.0.0rc1-py38h32f6830_0.tar.bz2
+osx-64/pytest-6.0.0rc1-py36hc560c46_0.tar.bz2
+osx-64/pytest-6.0.0rc1-py37hc8dfbb8_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
This is a dev/rc release that was put on the main channel. Per our policies, dev releases need to be on separate channels to avoid disruptions to users. See https://github.com/conda-forge/cfep/blob/master/cfep-05.md

This release is also breaking stuff for at least one user. See this quote from gitter

```
Duncan Macleod @duncanmmacleod 08:37
hi all, not sure if this is the best channel, but is there an easy way to get conda to not install rcX packages? pytest-6.0.0rc1 is now on conda-forge, but I don't really want to use release candidates (my CI is crashing because distutils.version.StrictVersion can't handle that version number)
```

@conda-forge/pytest 

cc @duncanmmacleod @conda-forge/core 