### PR TITLE
request yamllint 1.24.0 be marked broken

### DIFF
--- a/broken/yamllint-124.txt
+++ b/broken/yamllint-124.txt
@@ -1,0 +1,1 @@
+noarch/yamllint-1.24.0-pyh9f0ad1d_0.tar.bz2


### PR DESCRIPTION
Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

on https://github.com/conda-forge/yamllint-feedstock/pull/24, we added some test skips to get the package out, but it turns out it was a real bug, swiftly corrected upstream.  https://github.com/conda-forge/yamllint-feedstock/pull/25 (merged) fixes it. I can verify the `1.24.0` we posted is definitely broken in many locale setups... it's not worth working around, though, and I'd rather not have to support inevitable errors.

ping @conda-forge/yamllint 
