### PR TITLE
mark build _3 of curl as unbroken

### DIFF
--- a/not_broken/unbroken.txt
+++ b/not_broken/unbroken.txt
@@ -1,0 +1,3 @@
+osx-64/libcurl-7.71.1-he6690cf_3.tar.bz2
+osx-64/curl-7.71.1-hbdca1c0_3.tar.bz2
+osx-64/libcurl-static-7.71.1-he6690cf_3.tar.bz2


### PR DESCRIPTION
the other prs to fix this mess are:

- https://github.com/conda-forge/libssh2-feedstock/pull/41
- https://github.com/conda-forge/openssl-feedstock/pull/58
- https://github.com/conda-forge/krb5-feedstock/pull/25

@isuruf says we should mark curl unbroken first, then merge the other packages