### PR TITLE
Mark chemfiles 0.9.3 build 1 as broken

### DIFF
--- a/broken/chemfiles.txt
+++ b/broken/chemfiles.txt
@@ -1,3 +1,6 @@
 win-64/chemfiles-lib-0.9.3-he63f309_1.tar.bz2
 osx-64/chemfiles-lib-0.9.3-hc030df3_1.tar.bz2
 linux-64/chemfiles-lib-0.9.3-ha684736_1.tar.bz2
+win-64/chemfiles-lib-0.9.3-h1d1ba74_2.tar.bz2
+osx-64/chemfiles-lib-0.9.3-hae410c0_2.tar.bz2
+linux-64/chemfiles-lib-0.9.3-hbcb5575_2.tar.bz2

--- a/broken/chemfiles.txt
+++ b/broken/chemfiles.txt
@@ -1,0 +1,3 @@
+win-64/chemfiles-lib-0.9.3-he63f309_1.tar.bz2
+osx-64/chemfiles-lib-0.9.3-hc030df3_1.tar.bz2
+linux-64/chemfiles-lib-0.9.3-ha684736_1.tar.bz2


### PR DESCRIPTION
As we realized in MDAnalysis/mdanalysis#2798, conda-forge/chemfiles-lib-feedstock#33 had some unintentional fallout: chemfiles now uses the version of libnetcdf provided by conda-forge, butsSince the code was built with libnetcdf==4.7.4, this means the .so file it looks for is libnetcdf.so.18, making the code incompatible with other versions of libnetcdf, in particular 4.6.* which seems to only provides libnetcdf.so.15. To reflect this, I updated dependencies requirements in conda-forge/chemfiles-lib-feedstock#34 and changed the build number to 2. 

I would like to mark the build number 1 as broken to ensure it is no longer picked by conda, while I figure out what is the best solution here.

----

As a side note, the issue appeared when trying to use both netcdf4 and chemfiles in the same conda environment. It looks like the dependency on libnetcdf from netcdf4 is a bit strange: `conda info netcdf4==1.5.3 | grep libnetcdf` gives me widly varying versions depending on the build: `libnetcdf >=4.7.3,<4.7.3.1.0a0 mpi_mpich_*`/`libnetcdf >=4.7.1,<4.7.2.0a0`/`libnetcdf >=4.7.4,<4.7.5.0a0`. It seems to look better with netcdf4==1.5.4, I don't know if this can be improved for 1.5.3 too.
