### PR TITLE
Oops, one more Python 3.8.5 build to mark broken

### DIFF
--- a/broken/python-split-windows-2.txt
+++ b/broken/python-split-windows-2.txt
@@ -1,1 +1,1 @@
-win-64/python-3.8.5-h60c2a47_2_cpython.tar.bz2
+win-64/python-3.8.5-h60c2a47_2.tar.bz2

--- a/broken/python-split-windows-2.txt
+++ b/broken/python-split-windows-2.txt
@@ -1,0 +1,1 @@
+win-64/python-3.8.5-h60c2a47_2_cpython.tar.bz2


### PR DESCRIPTION
Following up #116. It turns out one package was missed: there are two _2 builds, h60c2a47_2 and h5fd99cc_2. The former is also broken, the latter looks OK.

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

xref https://github.com/conda-forge/tectonic-feedstock/issues/21
cc @conda-forge/python @isuruf