### PR TITLE
nbclient broken build

### DIFF
--- a/broken/nbclient.txt
+++ b/broken/nbclient.txt
@@ -1,0 +1,1 @@
+noarch/nbclient-0.4.2-py_0.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

We should have released 0.5 instead of 0.4.2 (because of breaking changes).
0.4.2 and 0.4.3 are already yanked in PyPI. Only 0.4.2 was released on conda-forge.
See:
https://github.com/conda-forge/nbclient-feedstock/issues/8
https://github.com/jupyter/nbclient/issues/103