### PR TITLE
pulp[version=2.3,build_number=0] broken

### DIFF
--- a/broken/pulp-2.3-0.txt
+++ b/broken/pulp-2.3-0.txt
@@ -1,0 +1,1 @@
+noarch/pulp-2.3-pyh9f0ad1d_0.tar.bz2


### PR DESCRIPTION
Newer PuLP versions don't include a default solver.
`pulp[version=2.3,build_number=1]` has a dep on external LP solvers now.

cc @johanneskoester @conda-forge/pulp