### PR TITLE
Build 0 of 0.20.2 broke binary compatibility

### DIFF
--- a/broken/xwidgets.txt
+++ b/broken/xwidgets.txt
@@ -1,0 +1,3 @@
+win-64/xwidgets-0.20.2-h7ef1ec2_0.tar.bz2
+osx-64/xwidgets-0.20.2-h879752b_0.tar.bz2
+linux-64/xwidgets-0.20.2-hc9558a2_0.tar.bz2


### PR DESCRIPTION
Cf https://github.com/conda-forge/xwidgets-feedstock/pull/17

Build number 0 would crash xeus-cling while build 1 does not.

The main difference between the two builds is the version of binutils used. 2.34 vs 2.35.

cc @conda-forge/xwidgets 

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
