### PR TITLE
Build 0 of Pyppeteer 0.2.2 missed an import in conda-forge patch

### DIFF
--- a/broken/pyppeteer.txt
+++ b/broken/pyppeteer.txt
@@ -1,0 +1,1 @@
+noarch/pyppeteer-0.2.2-py_0.tar.bz2


### PR DESCRIPTION
Cf https://github.com/conda-forge/pyppeteer-feedstock/pull/6, there was a missing import in the patch.

cc @conda-forge/pyppeteer 

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.