### PR TITLE
xeus 0.24.2 builds 0 are broken

### DIFF
--- a/broken/xeus.txt
+++ b/broken/xeus.txt
@@ -1,0 +1,10 @@
+linux-aarch64/xeus-0.24.2-hc49d203_0.tar.bz2
+win-64/xeus-0.24.2-h276ee43_0.tar.bz2
+osx-64/xeus-0.24.2-h52537a5_0.tar.bz2
+linux-ppc64le/xeus-0.24.2-hd57d3bd_0.tar.bz2
+linux-64/xeus-0.24.2-h841dea4_0.tar.bz2
+linux-aarch64/xeus-0.24.2-hc2e5408_0.tar.bz2
+win-64/xeus-0.24.2-h7ef1ec2_0.tar.bz2
+osx-64/xeus-0.24.2-h879752b_0.tar.bz2
+linux-64/xeus-0.24.2-h4d8c418_0.tar.bz2
+linux-ppc64le/xeus-0.24.2-had093f3_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [ ] Added links to any relevant issues/PRs in the PR description.
* [ ] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

`xeus 0.24.2` has been built with constraints on `zeromq` instead of relying on `conda-forge-pinning`. This results in pulling `zeromq 4.3.3` when installing `xeus`, leading to conflict with other packages of the Jupyter ecosystem. Relaxing this constraint in a new build is not enough since `conda` seems to pick up the xeus package that pulls the most recent version of `zeromq` instead of the xeus package with the highest build number.

Also when I first relaxed the constraint, I forgot to increase the build number ...