### PR TITLE
remove noarch/pymc3-3.9.3-py_0.tar.bz2

### DIFF
--- a/broken/broken.txt
+++ b/broken/broken.txt
@@ -1,0 +1,1 @@
+noarch/pymc3-3.9.3-py_0.tar.bz2


### PR DESCRIPTION
This one has a bad python dependency. Ideally we should repo-patch it but this is simpler for now.