### PR TITLE
Mark first builds of xvega as broken

### DIFF
--- a/broken/xvega.txt
+++ b/broken/xvega.txt
@@ -1,0 +1,12 @@
+win-64/xvega-0.0.4-h7ef1ec2_0.tar.bz2
+osx-64/xvega-0.0.4-h879752b_0.tar.bz2
+linux-64/xvega-0.0.4-hc9558a2_0.tar.bz2
+win-64/xvega-0.0.3-h7ef1ec2_0.tar.bz2
+osx-64/xvega-0.0.3-h879752b_0.tar.bz2
+linux-64/xvega-0.0.3-hc9558a2_0.tar.bz2
+win-64/xvega-0.0.2-h7ef1ec2_0.tar.bz2
+osx-64/xvega-0.0.2-h879752b_0.tar.bz2
+linux-64/xvega-0.0.2-hc9558a2_0.tar.bz2
+win-64/xvega-0.0.1-h7ef1ec2_0.tar.bz2
+osx-64/xvega-0.0.1-h879752b_0.tar.bz2
+linux-64/xvega-0.0.1-hc9558a2_0.tar.bz2


### PR DESCRIPTION
The first builds of xvega were not properly constraining the version of nlohmann_json used at runtime based on the version used at build time with `run_exports` and `pin_compatible`. Cf https://github.com/conda-forge/xvega-feedstock/issues/5.

Ping @conda-forge/xvega 

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.