### PR TITLE
Broken: noarch nose (build 1005)

### DIFF
--- a/broken/nose.txt
+++ b/broken/nose.txt
@@ -1,0 +1,1 @@
+noarch/nose-1.3.7-pyh9f0ad1d_1005.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

`nose` can't be fully noarch because it generates different code for Python 2 and Python 3 (dealing with metaclasses). See details in https://github.com/conda-forge/nose-feedstock/issues/23.

New build in https://github.com/conda-forge/nose-feedstock/pull/24.

ping @conda-forge/nose

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
