### PR TITLE
remove redis

### DIFF
--- a/broken/broken.txt
+++ b/broken/broken.txt
@@ -1,0 +1,1 @@
+noarch/redis-3.5.3-py_0.tar.bz2


### PR DESCRIPTION
This is a duplicate of redis-py and not the same package as redis from defaults. We should remove this ASAP.