### PR TITLE
Mark ovito 3 windows broken because of wrong install path.

### DIFF
--- a/broken/ovito-windows.txt
+++ b/broken/ovito-windows.txt
@@ -1,0 +1,2 @@
+win-64/ovito-3.3.1-h9b41f59_0.tar.bz2
+win-64/ovito-3.3.1-h4b8d5ed_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

The install path was wrong and the packages are fixed in https://github.com/conda-forge/ovito-feedstock/pull/35 (reported in https://github.com/conda-forge/ovito-feedstock/issues/34)

@conda-forge/ovito, @jan-janssen 

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/ovito

-->
