### PR TITLE
yank django 3.1.2-0 release

### DIFF
--- a/broken/django-3.1.2.txt
+++ b/broken/django-3.1.2.txt
@@ -1,0 +1,1 @@
+noarch/django-3.1.2-py_0.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

---

I noticed something weird in https://github.com/conda-forge/prospector-feedstock/pull/15 where the PR was[ broken during verification because a django dependency (asgiref) was not present with the correct version](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=234149&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d):

```
The following NEW packages will be INSTALLED:
    asgiref:               3.3.0-py_0               conda-forge
    django:                3.1.2-py_0               conda-forge
(..)
django 3.1.2 has requirement asgiref~=3.2.10, but you have asgiref 3.3.0.
```

You can reproduce this by creating a new conda environment with
```
$ conda create -p thing -c conda-forge --strict-channel-priority pylint-django
```
which currently comes up with the same _technically_ correct package combination.
This is because the django 3.1.2-0 recipe allowed asgiref `>=3.2,<4` and 3.1.2-1 restricted this further to `>=3.2.10,<3.3` in https://github.com/conda-forge/django-feedstock/pull/109.

However, if you try
```
$ mamba create -p thing -c conda-forge --strict-channel-priority pylint-django
```
you end up with
```
  asgiref                 3.2.10  py_0                conda-forge/noarch       Cached
  django                   3.1.2  py_1                conda-forge/noarch       Cached
```
which is the _working_ kind of correct.

So when setting up the environment conda has a choice of 
* picking a newer `asgiref` package (newer version) together with an older `django` build (same version, lower build number), **OR** 
* an older `asgiref` package (older version) together with a newer `django` build (higher build number).

From a packaging perspective both are equally valid, and conda prefers the former and mamba the latter.
Unfortunately only one of them works.

In my pull request where this came up I was able to fix this by enforcing the correct asgiref version in https://github.com/conda-forge/prospector-feedstock/pull/15/commits/b61b3477c74bbe398ca09dda7c916ab5550827cc but that is of course not scalable and a bit silly really.

I believe the correct solution is to pull django 3.1.2-0.


ping @conda-forge/django and @ocefpaf 
