### PR TITLE
Mark as broken noarch/grpcio-health-checking-1.33.2-py*_0.tar.bz2 (bad protobuf pin)

### DIFF
--- a/broken/grpcio-health-checking.txt
+++ b/broken/grpcio-health-checking.txt
@@ -1,0 +1,1 @@
+noarch/grpcio-health-checking-1.33.2-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

ping @conda-forge/grpcio-health-checking (it's just me)

@s22chan brought https://github.com/conda-forge/grpcio-health-checking-feedstock/issues/1 to my attention (thanks!): it's the first release of the package, and has <50 downloads. The upstream metadata, while technically accurate, doesn't reflect that the bulk of the code is generated with a _signficantly_ newer `protoc` than documented. 

https://github.com/conda-forge/grpcio-health-checking-feedstock/pull/2 added a lot more robustness to the testing, and should prevent this _particular_ problem from occurring in the future, though I keep finding more to not like about packaging protobuf-derived things...