### PR TITLE
Mark openexr 2.5.0 as broken

### DIFF
--- a/broken/example.txt
+++ b/broken/example.txt
@@ -1,7 +1,2 @@
 win-64/cf-autotick-bot-test-package-0.4-py38_0.tar.bz2
 win-64/cf-autotick-bot-test-package-0.4-py27_0.tar.bz2
-win-64/openexr-2.5.0-h5dfd299_0.tar.bz2
-linux-ppc64le/openexr-2.5.0-h6332354_0.tar.bz2
-osx-64/openexr-2.5.0-h7475705_0.tar.bz2
-linux-64/openexr-2.5.0-he513fc3_0.tar.bz2
-linux-aarch64/openexr-2.5.0-he513fc3_0.tar.bz2

--- a/broken/example.txt
+++ b/broken/example.txt
@@ -1,2 +1,7 @@
 win-64/cf-autotick-bot-test-package-0.4-py38_0.tar.bz2
 win-64/cf-autotick-bot-test-package-0.4-py27_0.tar.bz2
+win-64/openexr-2.5.0-h5dfd299_0.tar.bz2
+linux-ppc64le/openexr-2.5.0-h6332354_0.tar.bz2
+osx-64/openexr-2.5.0-h7475705_0.tar.bz2
+linux-64/openexr-2.5.0-he513fc3_0.tar.bz2
+linux-aarch64/openexr-2.5.0-he513fc3_0.tar.bz2

--- a/broken/openexr_250
+++ b/broken/openexr_250
@@ -1,0 +1,5 @@
+win-64/openexr-2.5.0-h5dfd299_0.tar.bz2
+linux-ppc64le/openexr-2.5.0-h6332354_0.tar.bz2
+osx-64/openexr-2.5.0-h7475705_0.tar.bz2
+linux-64/openexr-2.5.0-he513fc3_0.tar.bz2
+linux-aarch64/openexr-2.5.0-he513fc3_0.tar.bz2


### PR DESCRIPTION
There was an so name change between 2.5.0 and 2.5.1

https://github.com/conda-forge/conda-forge-pinning-feedstock/pulls?q=is%3Apr+is%3Aclosed

We want to pin to 2.X, but this version needs to be omitted.