### PR TITLE
Mark tqdm-4.53.0-pyhd3deb0d_0 as broken

### DIFF
--- a/broken/tqdm.txt
+++ b/broken/tqdm.txt
@@ -1,0 +1,1 @@
+noarch/tqdm-4.53.0-pyhd3deb0d_0.tar.bz2


### PR DESCRIPTION

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

ping @conda-forge/tqdm @jan-janssen 

tqdm added `setuptools_scm[toml]` to their `setup_requires`, which resulted in a `0.0.0` in the metadata on disk after `pip install`. the automerge on `tqdm-feedstock` shipped this version. This causes all subsequent `pip checks` to fail if any constraint is put on `tqdm`, causing issues for downstream builds. 

Related issues:
- original downstream work-around https://github.com/conda-forge/dagster-feedstock/pull/87/files#r528398464
- issue on tqdm feedstock https://github.com/conda-forge/tqdm-feedstock/issues/84
- pr to fix with correct `host` requirements: https://github.com/conda-forge/tqdm-feedstock/pull/85
  - my kingdom for a `pip check --setup-requires .`
- bad metadata PR https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/103/files#

Whew!