### PR TITLE
mark invalid packages for apache-libcloud as broken

### DIFF
--- a/broken/apache-libcloud-c5e85f21.txt
+++ b/broken/apache-libcloud-c5e85f21.txt
@@ -1,0 +1,10 @@
+linux-64/apache-libcloud-2.4.0-py27_1000.tar.bz2
+linux-64/apache-libcloud-2.4.0-py36_1000.tar.bz2
+linux-64/apache-libcloud-2.4.0-py37_1000.tar.bz2
+noarch/apache-libcloud-2.4.0-py_1000.tar.bz2
+osx-64/apache-libcloud-2.4.0-py27_1000.tar.bz2
+osx-64/apache-libcloud-2.4.0-py36_1000.tar.bz2
+osx-64/apache-libcloud-2.4.0-py37_1000.tar.bz2
+win-64/apache-libcloud-2.4.0-py27_1000.tar.bz2
+win-64/apache-libcloud-2.4.0-py36_1000.tar.bz2
+win-64/apache-libcloud-2.4.0-py37_1000.tar.bz2


### PR DESCRIPTION
Hi @conda-forge/!

The @conda-forge-daemon has made this PR because it has found files one or more
of your packages that are not allowed for that package. Once this PR is merged, the
builds listed below will be marked as broken. They will not be installable from the
main conda-forge channels, but you will still be able to download them from
anaconda.org.

If you think this PR was made by mistake or is incorrect, please get in touch with
the core team!

Information on invalid packages:

<details>

```
linux-64/apache-libcloud-2.4.0-py27_1000.tar.bz2:
  bad_paths:
    certifi.python.generated:
    - lib/python2.7/site-packages/certifi-2018.10.15.dist-info/DESCRIPTION.rst
  valid: false
linux-64/apache-libcloud-2.4.0-py36_1000.tar.bz2:
  bad_paths:
    certifi.python.generated:
    - lib/python3.6/site-packages/certifi-2018.10.15.dist-info/DESCRIPTION.rst
  valid: false
linux-64/apache-libcloud-2.4.0-py37_1000.tar.bz2:
  bad_paths:
    certifi.python.generated:
    - lib/python3.7/site-packages/certifi-2018.10.15.dist-info/DESCRIPTION.rst
  valid: false
noarch/apache-libcloud-2.4.0-py_1000.tar.bz2:
  bad_paths:
    certifi.python.generated:
    - site-packages/certifi-2018.10.15.dist-info/DESCRIPTION.rst
  valid: false
osx-64/apache-libcloud-2.4.0-py27_1000.tar.bz2:
  bad_paths:
    certifi.python.generated:
    - lib/python2.7/site-packages/certifi-2018.10.15.dist-info/DESCRIPTION.rst
  valid: false
osx-64/apache-libcloud-2.4.0-py36_1000.tar.bz2:
  bad_paths:
    certifi.python.generated:
    - lib/python3.6/site-packages/certifi-2018.10.15.dist-info/DESCRIPTION.rst
  valid: false
osx-64/apache-libcloud-2.4.0-py37_1000.tar.bz2:
  bad_paths:
    certifi.python.generated:
    - lib/python3.7/site-packages/certifi-2018.10.15.dist-info/DESCRIPTION.rst
  valid: false
win-64/apache-libcloud-2.4.0-py27_1000.tar.bz2:
  bad_paths:
    certifi.python.generated:
    - Lib/site-packages/certifi-2018.10.15.dist-info/DESCRIPTION.rst
  valid: false
win-64/apache-libcloud-2.4.0-py36_1000.tar.bz2:
  bad_paths:
    certifi.python.generated:
    - Lib/site-packages/certifi-2018.10.15.dist-info/DESCRIPTION.rst
  valid: false
win-64/apache-libcloud-2.4.0-py37_1000.tar.bz2:
  bad_paths:
    certifi.python.generated:
    - Lib/site-packages/certifi-2018.10.15.dist-info/DESCRIPTION.rst
  valid: false

```

</details>
