### PR TITLE
mark invalid packages for flask-debugtoolbar as broken

### DIFF
--- a/broken/flask-debugtoolbar-f4481d63.txt
+++ b/broken/flask-debugtoolbar-f4481d63.txt
@@ -1,0 +1,8 @@
+osx-64/flask-debugtoolbar-0.10.1-py27_1000.tar.bz2
+osx-64/flask-debugtoolbar-0.10.1-py35_1000.tar.bz2
+osx-64/flask-debugtoolbar-0.10.1-py36_1000.tar.bz2
+osx-64/flask-debugtoolbar-0.10.1-py37_1000.tar.bz2
+win-64/flask-debugtoolbar-0.10.1-py27_1000.tar.bz2
+win-64/flask-debugtoolbar-0.10.1-py35_1000.tar.bz2
+win-64/flask-debugtoolbar-0.10.1-py36_1000.tar.bz2
+win-64/flask-debugtoolbar-0.10.1-py37_1000.tar.bz2


### PR DESCRIPTION
Hi @conda-forge/flask-debugtoolbar! I am the friendly conda-forge webservice!

I made this PR because I found files in one or more of your packages that are not allowed for that package. Once this PR is merged, the builds listed below will be marked as broken. They will not be installable from the main conda-forge channels, but you will still be able to download them from anaconda.org.

The core team will usually wait a week to merge these PRs. However, we may merge them earlier if we deem the packages below a signifcant security or usability issue.

If you think this PR was made by mistake or is incorrect, please get in touch with the core team in this PR or on [gitter](https://gitter.im/conda-forge/conda-forge.github.io)!

Information on invalid packages (see the files listed under `bad_paths`):

<details>

```
osx-64/flask-debugtoolbar-0.10.1-py27_1000.tar.bz2:
  bad_paths:
    click.python.generated:
    - lib/python2.7/site-packages/click/__init__.py
  valid: false
osx-64/flask-debugtoolbar-0.10.1-py35_1000.tar.bz2:
  bad_paths:
    click.python.generated:
    - lib/python3.5/site-packages/click/__init__.py
  valid: false
osx-64/flask-debugtoolbar-0.10.1-py36_1000.tar.bz2:
  bad_paths:
    click.python.generated:
    - lib/python3.6/site-packages/click/__init__.py
  valid: false
osx-64/flask-debugtoolbar-0.10.1-py37_1000.tar.bz2:
  bad_paths:
    click.python.generated:
    - lib/python3.7/site-packages/click/__init__.py
  valid: false
win-64/flask-debugtoolbar-0.10.1-py27_1000.tar.bz2:
  bad_paths:
    click.python.generated:
    - Lib/site-packages/click/__init__.py
  valid: false
win-64/flask-debugtoolbar-0.10.1-py35_1000.tar.bz2:
  bad_paths:
    click.python.generated:
    - Lib/site-packages/click/__init__.py
  valid: false
win-64/flask-debugtoolbar-0.10.1-py36_1000.tar.bz2:
  bad_paths:
    click.python.generated:
    - Lib/site-packages/click/__init__.py
  valid: false
win-64/flask-debugtoolbar-0.10.1-py37_1000.tar.bz2:
  bad_paths:
    click.python.generated:
    - Lib/site-packages/click/__init__.py
  valid: false

```

</details>


This job was generated by https://github.com/conda-forge/artifact-validation/actions/runs/401834470.