### PR TITLE
mark invalid packages for google-api-core as broken

### DIFF
--- a/broken/google-api-core-cf6921e2.txt
+++ b/broken/google-api-core-cf6921e2.txt
@@ -1,0 +1,9 @@
+linux-64/google-api-core-1.20.1-py36h9f0ad1d_0.tar.bz2
+linux-64/google-api-core-1.20.1-py37hc8dfbb8_0.tar.bz2
+linux-64/google-api-core-1.20.1-py38h32f6830_0.tar.bz2
+osx-64/google-api-core-1.20.1-py36h9f0ad1d_0.tar.bz2
+osx-64/google-api-core-1.20.1-py37hc8dfbb8_0.tar.bz2
+osx-64/google-api-core-1.20.1-py38h32f6830_0.tar.bz2
+win-64/google-api-core-1.20.1-py36h9f0ad1d_0.tar.bz2
+win-64/google-api-core-1.20.1-py37hc8dfbb8_0.tar.bz2
+win-64/google-api-core-1.20.1-py38h32f6830_0.tar.bz2


### PR DESCRIPTION
Hi @conda-forge/google-api-core! I am the friendly conda-forge webservice!

I made this PR because I found files in one or more of your packages that are not allowed for that package. Once this PR is merged, the builds listed below will be marked as broken. They will not be installable from the main conda-forge channels, but you will still be able to download them from anaconda.org.

The core team will usually wait a week to merge these PRs. However, we may merge them earlier if we deem the packages below a signifcant security or usability issue.

If you think this PR was made by mistake or is incorrect, please get in touch with the core team in this PR or on [gitter](https://gitter.im/conda-forge/conda-forge.github.io)!

Information on invalid packages (see the files listed under `bad_paths`):

<details>

```
linux-64/google-api-core-1.20.1-py36h9f0ad1d_0.tar.bz2:
  bad_paths:
    requests.python.generated:
    - lib/python3.6/site-packages/requests-2.24.0.dist-info/DESCRIPTION.rst
  valid: false
linux-64/google-api-core-1.20.1-py37hc8dfbb8_0.tar.bz2:
  bad_paths:
    requests.python.generated:
    - lib/python3.7/site-packages/requests-2.24.0.dist-info/DESCRIPTION.rst
  valid: false
linux-64/google-api-core-1.20.1-py38h32f6830_0.tar.bz2:
  bad_paths:
    requests.python.generated:
    - lib/python3.8/site-packages/requests-2.24.0.dist-info/DESCRIPTION.rst
  valid: false
osx-64/google-api-core-1.20.1-py36h9f0ad1d_0.tar.bz2:
  bad_paths:
    requests.python.generated:
    - lib/python3.6/site-packages/requests-2.24.0.dist-info/DESCRIPTION.rst
  valid: false
osx-64/google-api-core-1.20.1-py37hc8dfbb8_0.tar.bz2:
  bad_paths:
    requests.python.generated:
    - lib/python3.7/site-packages/requests-2.24.0.dist-info/DESCRIPTION.rst
  valid: false
osx-64/google-api-core-1.20.1-py38h32f6830_0.tar.bz2:
  bad_paths:
    requests.python.generated:
    - lib/python3.8/site-packages/requests-2.24.0.dist-info/DESCRIPTION.rst
  valid: false
win-64/google-api-core-1.20.1-py36h9f0ad1d_0.tar.bz2:
  bad_paths:
    requests.python.generated:
    - Lib/site-packages/requests-2.24.0.dist-info/DESCRIPTION.rst
  valid: false
win-64/google-api-core-1.20.1-py37hc8dfbb8_0.tar.bz2:
  bad_paths:
    requests.python.generated:
    - Lib/site-packages/requests-2.24.0.dist-info/DESCRIPTION.rst
  valid: false
win-64/google-api-core-1.20.1-py38h32f6830_0.tar.bz2:
  bad_paths:
    requests.python.generated:
    - Lib/site-packages/requests-2.24.0.dist-info/DESCRIPTION.rst
  valid: false

```

</details>


This job was generated by https://github.com/conda-forge/artifact-validation/actions/runs/401834470.