### PR TITLE
mark invalid packages for google-cloud-bigquery-storage-core as broken

### DIFF
--- a/broken/google-cloud-bigquery-storage-core-65f68e9a.txt
+++ b/broken/google-cloud-bigquery-storage-core-65f68e9a.txt
@@ -1,0 +1,3 @@
+noarch/google-cloud-bigquery-storage-core-2.0.0-pyh9f0ad1d_1.tar.bz2
+noarch/google-cloud-bigquery-storage-core-2.0.1-pyh9f0ad1d_0.tar.bz2
+noarch/google-cloud-bigquery-storage-core-2.1.0-pyhd3deb0d_0.tar.bz2


### PR DESCRIPTION
Hi @conda-forge/google-cloud-bigquery-storage! I am the friendly conda-forge webservice!

I made this PR because I found files in one or more of your packages that are not allowed for that package. Once this PR is merged, the builds listed below will be marked as broken. They will not be installable from the main conda-forge channels, but you will still be able to download them from anaconda.org.

The core team will usually wait a week to merge these PRs. However, we may merge them earlier if we deem the packages below a signifcant security or usability issue.

If you think this PR was made by mistake or is incorrect, please get in touch with the core team in this PR or on [gitter](https://gitter.im/conda-forge/conda-forge.github.io)!

Information on invalid packages (see the files listed under `bad_paths`):

<details>

```
noarch/google-cloud-bigquery-storage-core-2.0.0-pyh9f0ad1d_1.tar.bz2:
  bad_paths:
    pyyaml.python.generated:
    - site-packages/PyYAML-5.3.1.dist-info/INSTALLER
  valid: false
noarch/google-cloud-bigquery-storage-core-2.0.1-pyh9f0ad1d_0.tar.bz2:
  bad_paths:
    pyyaml.python.generated:
    - site-packages/PyYAML-5.3.1.dist-info/INSTALLER
  valid: false
noarch/google-cloud-bigquery-storage-core-2.1.0-pyhd3deb0d_0.tar.bz2:
  bad_paths:
    pyyaml.python.generated:
    - site-packages/PyYAML-5.3.1.dist-info/INSTALLER
  valid: false

```

</details>


This job was generated by https://github.com/conda-forge/artifact-validation/actions/runs/401834470.