### PR TITLE
mark invalid packages for meshpy as broken

### DIFF
--- a/broken/meshpy-9c29d28f.txt
+++ b/broken/meshpy-9c29d28f.txt
@@ -1,0 +1,4 @@
+linux-64/meshpy-2018.2.1-py27h7eb728f_0.tar.bz2
+linux-64/meshpy-2018.2.1-py36h7eb728f_0.tar.bz2
+osx-64/meshpy-2018.2.1-py27h7eb728f_0.tar.bz2
+osx-64/meshpy-2018.2.1-py36h7eb728f_0.tar.bz2


### PR DESCRIPTION
Hi @conda-forge/meshpy! I am the friendly conda-forge webservice!

I made this PR because I found files in one or more of your packages that are not allowed for that package. Once this PR is merged, the builds listed below will be marked as broken. They will not be installable from the main conda-forge channels, but you will still be able to download them from anaconda.org.

The core team will usually wait a week to merge these PRs. However, we may merge them earlier if we deem the packages below a signifcant security or usability issue.

If you think this PR was made by mistake or is incorrect, please get in touch with the core team in this PR or on [gitter](https://gitter.im/conda-forge/conda-forge.github.io)!

Information on invalid packages (see the files listed under `bad_paths`):

<details>

```
linux-64/meshpy-2018.2.1-py27h7eb728f_0.tar.bz2:
  bad_paths:
    numpy.python.generated:
    - lib/python2.7/site-packages/numpy-1.15.4.dist-info/INSTALLER
  valid: false
linux-64/meshpy-2018.2.1-py36h7eb728f_0.tar.bz2:
  bad_paths:
    numpy.python.generated:
    - lib/python3.6/site-packages/numpy-1.15.4.dist-info/INSTALLER
  valid: false
osx-64/meshpy-2018.2.1-py27h7eb728f_0.tar.bz2:
  bad_paths:
    numpy.python.generated:
    - lib/python2.7/site-packages/numpy-1.15.4.dist-info/INSTALLER
  valid: false
osx-64/meshpy-2018.2.1-py36h7eb728f_0.tar.bz2:
  bad_paths:
    numpy.python.generated:
    - lib/python3.6/site-packages/numpy-1.15.4.dist-info/INSTALLER
  valid: false

```

</details>


This job was generated by https://github.com/conda-forge/artifact-validation/actions/runs/401834470.