### PR TITLE
mark invalid packages for racket as broken

### DIFF
--- a/broken/racket-8e1e7427.txt
+++ b/broken/racket-8e1e7427.txt
@@ -1,0 +1,12 @@
+osx-64/racket-6.12-hfc679d8_0.tar.bz2
+osx-64/racket-7.0-h0a44026_2000.tar.bz2
+osx-64/racket-7.0-hfc679d8_0.tar.bz2
+osx-64/racket-7.0-hfc679d8_1000.tar.bz2
+osx-64/racket-7.1-h0a44026_1000.tar.bz2
+osx-64/racket-7.1-hfc679d8_0.tar.bz2
+osx-64/racket-7.2-h0a44026_0.tar.bz2
+osx-64/racket-7.3-h6de7cb9_0.tar.bz2
+osx-64/racket-7.4-h6de7cb9_0.tar.bz2
+osx-64/racket-7.5-h4a8c4bd_0.tar.bz2
+osx-64/racket-7.7-h4a8c4bd_0.tar.bz2
+osx-64/racket-7.8-hb1e8313_0.tar.bz2


### PR DESCRIPTION
Hi @conda-forge/racket! I am the friendly conda-forge webservice!

I made this PR because I found files in one or more of your packages that are not allowed for that package. Once this PR is merged, the builds listed below will be marked as broken. They will not be installable from the main conda-forge channels, but you will still be able to download them from anaconda.org.

The core team will usually wait a week to merge these PRs. However, we may merge them earlier if we deem the packages below a signifcant security or usability issue.

If you think this PR was made by mistake or is incorrect, please get in touch with the core team in this PR or on [gitter](https://gitter.im/conda-forge/conda-forge.github.io)!

Information on invalid packages (see the files listed under `bad_paths`):

<details>

```
osx-64/racket-6.12-hfc679d8_0.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.0.0.dylib
  valid: false
osx-64/racket-7.0-h0a44026_2000.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.1.dylib
  valid: false
osx-64/racket-7.0-hfc679d8_0.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.1.dylib
  valid: false
osx-64/racket-7.0-hfc679d8_1000.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.1.dylib
  valid: false
osx-64/racket-7.1-h0a44026_1000.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.1.dylib
  valid: false
osx-64/racket-7.1-hfc679d8_0.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.1.dylib
  valid: false
osx-64/racket-7.2-h0a44026_0.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.1.dylib
  valid: false
osx-64/racket-7.3-h6de7cb9_0.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.1.dylib
  valid: false
osx-64/racket-7.4-h6de7cb9_0.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.1.dylib
  valid: false
osx-64/racket-7.5-h4a8c4bd_0.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.1.dylib
  valid: false
osx-64/racket-7.7-h4a8c4bd_0.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.1.dylib
  valid: false
osx-64/racket-7.8-hb1e8313_0.tar.bz2:
  bad_paths:
    openssl.generated:
    - lib/libcrypto.1.1.dylib
  valid: false

```

</details>


This job was generated by https://github.com/conda-forge/artifact-validation/actions/runs/401834470.