### PR TITLE
mark tpot-0.11.6.post2-*_0 broken

### DIFF
--- a/broken/tpot.txt
+++ b/broken/tpot.txt
@@ -1,0 +1,1 @@
+noarch/tpot-0.11.6.post2-pyhd3deb0d_0.tar.bz2


### PR DESCRIPTION
`tpot` upstream added a hard dependency on `py-xgboost`, and automerge shipped it (because we had it as a test dep). 

practically, this means `tpot-0.11.6.post1` will be the last version that works on windows until somebody (not me, :weary:) picks up [this PR](https://github.com/conda-forge/xgboost-feedstock/pull/43). Sigh.

- tracking issue: https://github.com/conda-forge/tpot-feedstock/issues/30
- `1` with correct deps, just merged: https://github.com/conda-forge/tpot-feedstock/pull/31
  - also removes automerge
    - this has happened before (torch, but that got rolled back)
    - we can put it back if...
      - `conda-build` adds the ability to do multiple test sections (e.g. a dedicated one for `pip check`)
      - we do multiple outputs, so we can `pip` check `tpot-core`
        - https://github.com/conda-forge/tpot-feedstock/issues/19
    
:bellhop_bell:  @conda-forge/tpot

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.