### PR TITLE
remove noarch openquake.engine-3.10.1 pyhd8ed1ab_1

### DIFF
--- a/broken/broken.txt
+++ b/broken/broken.txt
@@ -1,0 +1,1 @@
+noarch/openquake.engine-3.10.1-pyhd8ed1ab_1.tar.bz2


### PR DESCRIPTION
This package is not installable on Windows due to a bad manifest. See https://dev.azure.com/conda-forge/84710dde-1620-425b-80d0-4cf5baca359d/_apis/build/builds/253336/logs/63