### PR TITLE
remove noarch openquake.engine-3.10.1 build 0

### DIFF
--- a/broken/broken.txt
+++ b/broken/broken.txt
@@ -1,0 +1,1 @@
+noarch/openquake.engine-3.10.1-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
Build 0 has the same issue as 1. See #205 