### PR TITLE
Mark ipython-7.19.0_0 as broken

### DIFF
--- a/broken/ipython-7.19.0_0.txt
+++ b/broken/ipython-7.19.0_0.txt
@@ -1,0 +1,17 @@
+linux-64/ipython-7.19.0-py37h888b3d9_0.tar.bz2 
+linux-64/ipython-7.19.0-py38h81c977d_0.tar.bz2
+linux-64/ipython-7.19.0-py39hef51801_0.tar.bz2
+linux-aarch64/ipython-7.19.0-py37hc16ab0a_0.tar.bz2
+linux-aarch64/ipython-7.19.0-py38hd825144_0.tar.bz2
+linux-aarch64/ipython-7.19.0-py39hef158d4_0.tar.bz2
+linux-ppc64le/ipython-7.19.0-py37h7b46356_0.tar.bz2
+linux-ppc64le/ipython-7.19.0-py38h3c958fc_0.tar.bz2
+linux-ppc64le/ipython-7.19.0-py39h0de2273_0.tar.bz2
+osx-64/ipython-7.19.0-py37he01cfaa_0.tar.bz2
+osx-64/ipython-7.19.0-py38h9bb44b7_0.tar.bz2
+osx-64/ipython-7.19.0-py39h71a6800_0.tar.bz2
+osx-arm64/ipython-7.19.0-py38h2cb4d76_0.tar.bz2
+osx-arm64/ipython-7.19.0-py39h32adebf_0.tar.bz2
+win-64/ipython-7.19.0-py37heaed05f_0.tar.bz2
+win-64/ipython-7.19.0-py38hc5df569_0.tar.bz2
+win-64/ipython-7.19.0-py39h832f523_0.tar.bz2


### PR DESCRIPTION
Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

All of these builds allow the fairly cripplingly- (and cryptically-) incompatible `jedi==0.18.0`, which makes completion not work. We patched them with a subsequent build, but did not mark these as broken, but have heard from users that this isn't enough to keep things like https://github.com/conda-forge/ipython-feedstock/issues/125 from happening.

ping @conda-forge/ipython