### PR TITLE
ENH mark latest clang activation broken

### DIFF
--- a/broken/clang.txt
+++ b/broken/clang.txt
@@ -1,0 +1,16 @@
+linux-64/clang_osx-64-11.0.0-hc3c9db2_9.tar.bz2
+linux-64/clangxx_osx-64-11.0.0-h060219b_9.tar.bz2
+linux-64/clangxx_osx-arm64-11.0.0-h6cb47b6_9.tar.bz2
+linux-64/clang_osx-arm64-11.0.0-hbb50d1d_9.tar.bz2
+osx-64/clang_osx-64-11.0.0-hb91bd55_9.tar.bz2
+osx-64/clang_bootstrap_osx-64-11.0.0-h3b6de16_9.tar.bz2
+osx-64/clangxx_osx-64-11.0.0-h7e1b574_9.tar.bz2
+osx-64/clangxx_osx-arm64-11.0.0-hc50fe25_9.tar.bz2
+osx-64/clang_osx-arm64-11.0.0-h40be2b1_9.tar.bz2
+osx-64/clang_bootstrap_osx-arm64-11.0.0-h75a6d7f_9.tar.bz2
+osx-arm64/clangxx_osx-64-11.0.0-h8d3ee1a_9.tar.bz2
+osx-arm64/clang_osx-64-11.0.0-ha77c5c3_9.tar.bz2
+osx-arm64/clang_bootstrap_osx-64-11.0.0-ha99727f_9.tar.bz2
+osx-arm64/clang_bootstrap_osx-arm64-11.0.0-h1741c7c_9.tar.bz2
+osx-arm64/clangxx_osx-arm64-11.0.0-hb84c830_9.tar.bz2
+osx-arm64/clang_osx-arm64-11.0.0-h54d7cd3_9.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

This version of the scripts has some buggy zsh in the activation / deactivation bits. This was hopefully fixed by https://github.com/conda-forge/clang-compiler-activation-feedstock/pull/52

cc @erykoff @isuruf 