### PR TITLE
mark as broken robotframework-seleniumlibrary-5.0.0-*_0.tar.bz2

### DIFF
--- a/broken/robotframework-seleniumlibrary.txt
+++ b/broken/robotframework-seleniumlibrary.txt
@@ -1,0 +1,1 @@
+noarch/robotframework-seleniumlibrary-5.0.0-pyh44b312d_0.tar.bz2


### PR DESCRIPTION
Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

References:
- merged https://github.com/conda-forge/robotframework-seleniumlibrary-feedstock/pull/10 without properly reviewing the upstream (new `python_requires`) ... _and_ ignored the linter, warning me of the same :blush: 
- https://github.com/conda-forge/robotframework-seleniumlibrary-feedstock/pull/11 is open to fix

ping @conda-forge/robotframework-seleniumlibrary (mostly me, sorry y'all)