### PR TITLE
Mark ipykernel 5.1.0 noarch as broken

### DIFF
--- a/broken/ipykernel_noarch.txt
+++ b/broken/ipykernel_noarch.txt
@@ -1,0 +1,1 @@
+noarch/ipykernel-5.1.0-pyh24bf2e0_0.tar.bz2


### PR DESCRIPTION
For some reason conda picks up up an old noarch build of ipykernel (5.1.0) and it happen that this package is broken on windows; working fine on linux.

To reproduce (specify ipykernel=5.1.0 if a more recent version is pickep up)
```
conda create -n test python=3.8 jupyter_console
```
```
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... 
Warning: 2 possible package resolutions (only showing differing packages):
  - defaults/noarch::ipykernel-5.1.0-pyh24bf2e0_0, defaults/win-64::pyzmq-22.0.3-py38h7a0e47e_0
  - defaults/win-64::ipykernel-5.4.3-py38hc5df569_0, defaults/win-64::pyzmq-20.0.0-py38h7a0e47e_1done

## Package Plan ##

  environment location: C:\Users\Eric\HyperSpy-bundle\envs\test2

  added / updated specs:
    - jupyter_console
    - python=3.8


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    backcall-0.2.0             |     pyh9f0ad1d_0          13 KB
    backports-1.0              |             py_2           4 KB
    backports.functools_lru_cache-1.6.1|             py_0           8 KB
    colorama-0.4.4             |     pyh9f0ad1d_0          18 KB
    decorator-4.4.2            |             py_0          11 KB
    ipykernel-5.1.0            |     pyh24bf2e0_0          77 KB
    ipython_genutils-0.2.0     |             py_1          21 KB
    jedi-0.18.0                |   py38haa244fe_2         931 KB
    jupyter_client-6.1.11      |     pyhd8ed1ab_1          76 KB
    jupyter_console-6.2.0      |             py_0          22 KB
    libsodium-1.0.18           |       h8d14728_1         697 KB
    parso-0.8.1                |     pyhd8ed1ab_0          67 KB
    pickleshare-0.7.5          |          py_1003           9 KB
    prompt-toolkit-3.0.16      |     pyha770c72_0         244 KB
    prompt_toolkit-3.0.16      |       hd8ed1ab_0           4 KB
    pygments-2.8.0             |     pyhd8ed1ab_0         736 KB
    python-dateutil-2.8.1      |             py_0         220 KB
    pywin32-300                |   py38h294d835_0         7.0 MB
    pyzmq-22.0.3               |   py38h7a0e47e_0         697 KB
    six-1.15.0                 |     pyh9f0ad1d_0          14 KB
    tornado-6.1                |   py38h294d835_1         649 KB
    traitlets-5.0.5            |             py_0          81 KB
    wcwidth-0.2.5              |     pyh9f0ad1d_2          33 KB
    zeromq-4.3.3               |       h0e60522_3         9.0 MB
    ------------------------------------------------------------
                                           Total:        20.5 MB

The following NEW packages will be INSTALLED:

  backcall           conda-forge/noarch::backcall-0.2.0-pyh9f0ad1d_0
  backports          conda-forge/noarch::backports-1.0-py_2
  backports.functoo~ conda-forge/noarch::backports.functools_lru_cache-1.6.1-py_0
  ca-certificates    conda-forge/win-64::ca-certificates-2020.12.5-h5b45459_0
  certifi            conda-forge/win-64::certifi-2020.12.5-py38haa244fe_1
  colorama           conda-forge/noarch::colorama-0.4.4-pyh9f0ad1d_0
  decorator          conda-forge/noarch::decorator-4.4.2-py_0
  ipykernel          conda-forge/noarch::ipykernel-5.1.0-pyh24bf2e0_0
  ipython            conda-forge/win-64::ipython-7.20.0-py38hc5df569_2
  ipython_genutils   conda-forge/noarch::ipython_genutils-0.2.0-py_1
  jedi               conda-forge/win-64::jedi-0.18.0-py38haa244fe_2
  jupyter_client     conda-forge/noarch::jupyter_client-6.1.11-pyhd8ed1ab_1
  jupyter_console    conda-forge/noarch::jupyter_console-6.2.0-py_0
  jupyter_core       conda-forge/win-64::jupyter_core-4.7.1-py38haa244fe_0
  libsodium          conda-forge/win-64::libsodium-1.0.18-h8d14728_1
  openssl            conda-forge/win-64::openssl-1.1.1i-h8ffe710_0
  parso              conda-forge/noarch::parso-0.8.1-pyhd8ed1ab_0
  pickleshare        conda-forge/noarch::pickleshare-0.7.5-py_1003
  pip                conda-forge/noarch::pip-21.0.1-pyhd8ed1ab_0
  prompt-toolkit     conda-forge/noarch::prompt-toolkit-3.0.16-pyha770c72_0
  prompt_toolkit     conda-forge/noarch::prompt_toolkit-3.0.16-hd8ed1ab_0
  pygments           conda-forge/noarch::pygments-2.8.0-pyhd8ed1ab_0
  python             conda-forge/win-64::python-3.8.6-h7840368_5_cpython
  python-dateutil    conda-forge/noarch::python-dateutil-2.8.1-py_0
  python_abi         conda-forge/win-64::python_abi-3.8-1_cp38
  pywin32            conda-forge/win-64::pywin32-300-py38h294d835_0
  pyzmq              conda-forge/win-64::pyzmq-22.0.3-py38h7a0e47e_0
  setuptools         conda-forge/win-64::setuptools-49.6.0-py38haa244fe_3
  six                conda-forge/noarch::six-1.15.0-pyh9f0ad1d_0
  sqlite             conda-forge/win-64::sqlite-3.34.0-h8ffe710_0
  tornado            conda-forge/win-64::tornado-6.1-py38h294d835_1
  traitlets          conda-forge/noarch::traitlets-5.0.5-py_0
  vc                 conda-forge/win-64::vc-14.2-hb210afc_3
  vs2015_runtime     conda-forge/win-64::vs2015_runtime-14.28.29325-h5e1d092_3
  wcwidth            conda-forge/noarch::wcwidth-0.2.5-pyh9f0ad1d_2
  wheel              conda-forge/noarch::wheel-0.36.2-pyhd3deb0d_0
  wincertstore       conda-forge/win-64::wincertstore-0.2-py38haa244fe_1006
  zeromq             conda-forge/win-64::zeromq-4.3.3-h0e60522_3

```
Note that in this case, the conda doesn't seem to solve the environment in a deterministic manner: it can be picks one of the two:
- `conda-forge/noarch::ipykernel-5.1.0-pyh24bf2e0_0`
- `conda-forge/win-64::ipykernel-5.4.3-py38hc5df569_0`

If `ipykernel-5.1.0-pyh24bf2e0_0` is installed, starting a jupyter console fails:
```
conda activate test
jupyter console
```
with
```
[ZMQTerminalIPythonApp] ERROR | Failed to run command:
['C:/Users/Eric/HyperSpy-bundle/envs/test/bin/python', '-m', 'ipykernel_launcher', '-f', 'C:\\Users\\Eric\\AppData\\Roaming\\jupyter\\runtime\\kernel-6380.json']
    PATH='C:\\Users\\Eric\\HyperSpy-bundle\\envs\\test;C:\\Users\\Eric\\HyperSpy-bundle\\envs\\test\\Library\\mingw-w64\\bin;C:\\Users\\Eric\\HyperSpy-bundle\\envs\\test\\Library\\usr\\bin;C:\\Users\\Eric\\HyperSpy-bundle\\envs\\test\\Library\\bin;C:\\Users\\Eric\\HyperSpy-bundle\\envs\\test\\Scripts;C:\\Users\\Eric\\HyperSpy-bundle\\envs\\test\\bin;C:\\Users\\Eric\\HyperSpy-bundle\\condabin;.;C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v10.2\\bin;C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v10.2\\libnvvp;C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\Wbem;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0;C:\\WINDOWS\\System32\\OpenSSH;Plugins;C:\\Program Files\\Gatan\\Shared;C:\\Program Files\\NVIDIA Corporation\\NVIDIA NvDLISR;C:\\Program Files\\NVIDIA Corporation\\Nsight Compute 2020.1.0;C:\\Program Files (x86)\\NVIDIA Corporation\\PhysX\\Common;C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\Wbem;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0;C:\\WINDOWS\\System32\\OpenSSH;C:\\Users\\Eric\\AppData\\Local\\Microsoft\\WindowsApps;.'
    with kwargs:
{'stdin': -1, 'stdout': None, 'stderr': None, 'cwd': None, 'close_fds': False}

Traceback (most recent call last):
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\Scripts\jupyter-console-script.py", line 9, in <module>
    sys.exit(main())
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\site-packages\jupyter_core\application.py", line 254, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\site-packages\traitlets\config\application.py", line 844, in launch_instance
    app.initialize(argv)
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\site-packages\traitlets\config\application.py", line 87, in inner
    return method(app, *args, **kwargs)
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\site-packages\jupyter_console\app.py", line 137, in initialize
    self.init_shell()
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\site-packages\jupyter_console\app.py", line 104, in init_shell
    JupyterConsoleApp.initialize(self)
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\site-packages\jupyter_client\consoleapp.py", line 341, in initialize
    self.init_kernel_manager()
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\site-packages\jupyter_client\consoleapp.py", line 293, in init_kernel_manager
    self.kernel_manager.start_kernel(**kwargs)
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\site-packages\jupyter_client\manager.py", line 313, in start_kernel
    self.kernel = self._launch_kernel(kernel_cmd, **kw)
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\site-packages\jupyter_client\manager.py", line 222, in _launch_kernel
    return launch_kernel(kernel_cmd, **kw)
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\site-packages\jupyter_client\launcher.py", line 134, in launch_kernel
    proc = Popen(cmd, **kwargs)
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Users\Eric\HyperSpy-bundle\envs\test\lib\subprocess.py", line 1307, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
FileNotFoundError: [WinError 2] The system cannot find the file specified
```


<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [ ] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
ping @conda-forge/ipykernel
