### PR TITLE
Mark some srm-ifce builds as broken

### DIFF
--- a/broken/srm-ifce.txt
+++ b/broken/srm-ifce.txt
@@ -1,0 +1,4 @@
+linux-64/srm-ifce-1.24.4-h08bb679_0.tar.bz2
+osx-64/srm-ifce-1.24.4-hae3744b_0.tar.bz2
+linux-64/srm-ifce-1.24.4-h13806f4_1.tar.bz2
+osx-64/srm-ifce-1.24.4-he61573e_1.tar.bz2


### PR DESCRIPTION
Marks builds which were mis-compiled by the newer gsoap release. A workaround was applied in: https://github.com/conda-forge/srm-ifce-feedstock/pull/2

The bug is being investigated upstream in https://its.cern.ch/jira/browse/DMC-1240