### PR TITLE
mark initial win+cuda builds for faiss as broken

### DIFF
--- a/broken/faiss-gpu.txt
+++ b/broken/faiss-gpu.txt
@@ -1,0 +1,4 @@
+win-64/faiss-gpu-1.7.0-h949689a_2.tar.bz2
+win-64/faiss-gpu-1.7.0-h278398d_2.tar.bz2
+win-64/faiss-gpu-1.7.0-h6de129e_2.tar.bz2
+win-64/faiss-gpu-1.7.0-h79f9687_2.tar.bz2

--- a/broken/faiss-proc.txt
+++ b/broken/faiss-proc.txt
@@ -1,0 +1,1 @@
+win-64/faiss-proc-1.0.0-cuda.tar.bz2

--- a/broken/faiss.txt
+++ b/broken/faiss.txt
@@ -1,0 +1,16 @@
+win-64/faiss-1.7.0-py36cuda102hfea3036_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py37cuda102hcca7678_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py38cuda102hd0acab5_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py39cuda102hb2b37fc_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py36cuda110he90ffb2_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py37cuda110hab6dca5_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py38cuda110he1a03a8_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py39cuda110hd081a46_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py36cuda111h5cee61a_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py37cuda111hdef9593_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py38cuda111h74dd5d2_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py39cuda111h2e98a31_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py36cuda112h9dbca54_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py37cuda112h643ebe3_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py38cuda112he474264_2_cuda.tar.bz2
+win-64/faiss-1.7.0-py39cuda112h90a011b_2_cuda.tar.bz2

--- a/broken/libfaiss.txt
+++ b/broken/libfaiss.txt
@@ -1,0 +1,4 @@
+win-64/libfaiss-1.7.0-cuda102h75e95e8_2_cuda.tar.bz2
+win-64/libfaiss-1.7.0-cuda110h1346f91_2_cuda.tar.bz2
+win-64/libfaiss-1.7.0-cuda111h1b3ed02_2_cuda.tar.bz2
+win-64/libfaiss-1.7.0-cuda112h6b84137_2_cuda.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

After a long journey with https://github.com/conda-forge/faiss-split-feedstock/pull/19, things built fine, the CI ran through and the PR got merged. Once I tried the package locally, I found out that the GPU-specific test suite has some failures and segfaults.

Since these packages are only a few hours old and fundamentally broken for what they claim to do, I propose to mark them as broken.

PS. I should have tested this from the artefacts of the PR, sorry for the bother.

CC @beckermr @isuruf