### PR TITLE
mark noarch/spacy-model-en_core_web_*_0 broken

### DIFF
--- a/broken/spacy-model-en_core_web-3.0.0_0.txt
+++ b/broken/spacy-model-en_core_web-3.0.0_0.txt
@@ -1,0 +1,3 @@
+noarch/spacy-model-en_core_web_sm-3.0.0-pyh44b312d_0.tar.bz2
+noarch/spacy-model-en_core_web_md-3.0.0-pyh44b312d_0.tar.bz2
+noarch/spacy-model-en_core_web_lg-3.0.0-pyh44b312d_0.tar.bz2


### PR DESCRIPTION

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

Notes:
- reported on https://github.com/conda-forge/spacy-model-en_core_web-feedstock/issues/11
- affecting upstream https://github.com/conda-forge/allennlp-semparse-feedstock/pull/2
  - due to some weird pins, this was pulling `spacy=2` and `spacy-model-en_core_web_sm =3`
  - this hadn't really appeared before, as the models "pretty much worked" in `spacy 2`
- replacements available from https://github.com/conda-forge/spacy-model-en_core_web-feedstock/pull/12
  - now uses `run_constrained`, and at least points to the official compatibility matrix
    - in the future, might try to figure out a way to validate them...

ping @conda-forge/spacy-model-en_core_web @h-vetinari 