### PR TITLE
Remove freud osx-arm64 packages (fail on import)

### DIFF
--- a/broken/freud-osx-arm64.txt
+++ b/broken/freud-osx-arm64.txt
@@ -1,0 +1,2 @@
+osx-arm64/freud-2.4.1-py39ha0bc353_1.tar.bz2
+osx-arm64/freud-2.4.1-py38ha336496_1.tar.bz2


### PR DESCRIPTION
I added osx-arm64 support to freud in the PR linked below, but the builds segfault on import. It is not clear what causes the problem, but I want to remove the packages for now. https://github.com/conda-forge/freud-feedstock/pull/34/files

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [ ] Pinged the team for the package for their input.

Segfault output:

```
(lldb) run -c "import freud"
Process 62231 launched: '~/miniforge3/bin/python' (arm64)
Process 62231 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x10)
    frame #0: 0x0000000101b9f028 libpython3.9.dylib`_PyObject_GC_Alloc + 56
libpython3.9.dylib`_PyObject_GC_Alloc:
->  0x101b9f028 <+56>: ldr    x22, [x19, #0x10]
    0x101b9f02c <+60>: add    x2, x1, #0x10             ; =0x10 
    0x101b9f030 <+64>: adrp   x8, 309
    0x101b9f034 <+68>: add    x8, x8, #0xa90            ; =0xa90 
Target 0: (python) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x10)
  * frame #0: 0x0000000101b9f028 libpython3.9.dylib`_PyObject_GC_Alloc + 56
    frame #1: 0x0000000101a86490 libpython3.9.dylib`PyTuple_New + 284
    frame #2: 0x0000000101a8b1a0 libpython3.9.dylib`PyType_Ready + 284
    frame #3: 0x0000000101a8b150 libpython3.9.dylib`PyType_Ready + 204
    frame #4: 0x0000000101a6d09c libpython3.9.dylib`PyModuleDef_Init + 32
    frame #5: 0x0000000100198b30 python`_imp_create_dynamic + 2412
    frame #6: 0x00000001000b3bac python`cfunction_vectorcall_FASTCALL + 208
    frame #7: 0x0000000100165184 python`_PyEval_EvalFrameDefault + 30088
    frame #8: 0x000000010015d5b4 python`_PyEval_EvalCode + 2968
    frame #9: 0x0000000100060734 python`_PyFunction_Vectorcall + 240
```

The compiled libraries and linkages seem to be correct:

```
~/miniforge3/lib/python3.9/site-packages/freud ▶ file box.cpython-39-darwin.so                                                                                        
box.cpython-39-darwin.so: Mach-O 64-bit bundle arm64
~/miniforge3/lib/python3.9/site-packages/freud ▶ otool -L box.cpython-39-darwin.so                                                                                          
box.cpython-39-darwin.so:
        @rpath/libpython3.9.dylib (compatibility version 3.9.0, current version 3.9.0)
        @rpath/libtbb.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libc++.1.dylib (compatibility version 1.0.0, current version 1.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.0.0)
```