### PR TITLE
mark noarch/nteract-scrapbook-0.5.0-*_1 broken

### DIFF
--- a/broken/nteract-scrapbook-050.txt
+++ b/broken/nteract-scrapbook-050.txt
@@ -1,0 +1,1 @@
+noarch/nteract-scrapbook-0.5.0-pyh44b312d_1.tar.bz2


### PR DESCRIPTION
Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

The upstream package changed the distribution name (dropping the `nteract-` prefix). I added an alias package for depending on the old name, but it's causing issues for downstreams.

- added in https://github.com/conda-forge/nteract-scrapbook-feedstock/pull/6
- downstream issue reported on https://github.com/conda-forge/nteract-scrapbook-feedstock/issues/7
- fixed with https://github.com/conda-forge/nteract-scrapbook-feedstock/pull/8

@conda-forge/nteract-scrapbook 