### PR TITLE
remove libdap4 builds 0 and 1 for the 3.20.6 version

### DIFF
--- a/broken/libdap4.txt
+++ b/broken/libdap4.txt
@@ -1,0 +1,11 @@
+osx-64/libdap4-3.20.6-h8c15375_0.tar.bz2
+osx-64/libdap4-3.20.6-h75eb3ff_1.tar.bz2
+osx-64/libdap4-3.20.6-h993cace_1.tar.bz2
+osx-arm64/libdap4-3.20.6-h8510809_1.tar.bz2
+linux-aarch64/libdap4-3.20.6-hf7f982d_1.tar.bz2
+linux-aarch64/libdap4-3.20.6-h09dc028_1.tar.bz2
+linux-ppc64le/libdap4-3.20.6-h1e1d7db_1.tar.bz2
+linux-ppc64le/libdap4-3.20.6-h288a509_1.tar.bz2
+linux-64/libdap4-3.20.6-h1d1bd15_0.tar.bz2
+linux-64/libdap4-3.20.6-hd7c4107_1.tar.bz2
+linux-64/libdap4-3.20.6-h1d1bd15_1.tar.bz2


### PR DESCRIPTION
@isuruf these two have a run_exports that does not match the pinning. I guess it makes sense to move them to broken, right?