### PR TITLE
Mark some recent Windows libwebp-base packages as broken

### DIFF
--- a/broken/libwebp-base.txt
+++ b/broken/libwebp-base.txt
@@ -1,0 +1,3 @@
+win-64/libwebp-base-1.2.0-h8ffe710_1.tar.bz2
+win-64/libwebp-base-1.2.0-h8ffe710_0.tar.bz2
+ 


### PR DESCRIPTION
This two builds have the following problems:
* Missing `libwepmux.dll` file, causing problems such as https://github.com/conda-forge/freeimage-feedstock/issues/27 and fixed in https://github.com/conda-forge/libwebp-base-feedstock/pull/5
* Missing headers, fixed in https://github.com/conda-forge/libwebp-base-feedstock/pull/6

FYI @conda-forge/freeimage @conda-forge/libwebp-base @jakirkham @adam-urbanczyk  

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.
