### PR TITLE
mark faiss-proc unbroken for win+cuda again

### DIFF
--- a/not_broken/faiss-proc.txt
+++ b/not_broken/faiss-proc.txt
@@ -1,0 +1,1 @@
+win-64/faiss-proc-1.0.0-cuda.tar.bz2


### PR DESCRIPTION
Follow-up to #235 after https://github.com/conda-forge/faiss-split-feedstock/pull/32 has been merged.

In #235, I included the `faiss-proc` selector package as well, but since this does not get a new build number / version / hash, it just needs to be reinstated, now that builds have arrived.