### PR TITLE
Mark `librmm` build number `0` as broken

### DIFF
--- a/broken/librmm0.txt
+++ b/broken/librmm0.txt
@@ -1,0 +1,5 @@
+linux-64/librmm-0.19.0-h97a9cb7_0.tar.bz2
+linux-64/librmm-0.19.0-hdc17891_0.tar.bz2
+linux-64/librmm-0.19.0-h96e36e3_0.tar.bz2
+linux-64/librmm-0.19.0-h1a5f58c_0.tar.bz2
+linux-64/librmm-0.19.0-h8b44402_0.tar.bz2


### PR DESCRIPTION
These accidentally included some `spdlog` components that shouldn't have been in there. We've since fixed the issue ( https://github.com/conda-forge/librmm-feedstock/pull/3 ). Though it would be good to remove these packages so that users environments don't accidentally get clobbered by them

cc @isuruf @kkraus14 @leofang