### PR TITLE
Mark `msmpi` 10.1.1 builds 3, 4 and 10.1.2 builds 0, 1 as broken

### DIFF
--- a/broken/msmpi.txt
+++ b/broken/msmpi.txt
@@ -1,0 +1,4 @@
+win-64/msmpi-10.1.1-h3502643_4.tar.bz2
+win-64/msmpi-10.1.1-h3502643_3.tar.bz2
+win-64/msmpi-10.1.2-h3502643_1.tar.bz2
+win-64/msmpi-10.1.2-h3502643_0.tar.bz2


### PR DESCRIPTION
In the 4 listed builds we accidentally packaged 32-bit binaries, causing issues in downstream (mpi4py/mpi4py#19). In addition, in the first 2 builds of each version, `MSMPI_VER` was not correctly patched, so all users would see the default version (0x100), which lacks tons of features that MS-MPI actually implemented. All these are fixed after conda-forge/msmpi-feedstock#11.

The lack of the patching for `MSMPI_VER` also exists in earlier builds, but at least their binaries worked so it's ok to not mark them as broken.

cc: @conda-forge/msmpi @conda-forge/mpi4py 


<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
