### PR TITLE
Remove broken pyopencl 2021.2

### DIFF
--- a/broken/pyopencl-2021.2.txt
+++ b/broken/pyopencl-2021.2.txt
@@ -1,0 +1,6 @@
+linux-aarch64/pyopencl-2021.2-py37hce16e70_0.tar.bz2
+linux-64/pyopencl-2021.2-py39h5472131_0.tar.bz2
+linux-aarch64/pyopencl-2021.2-py36h93b45c7_0.tar.bz2
+linux-64/pyopencl-2021.2-py36h706143c_0.tar.bz2
+linux-64/pyopencl-2021.2-py37hda21425_0.tar.bz2
+linux-64/pyopencl-2021.2-py37h0379df6_0.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

These (ostensibly broken) versions of the pyopencl 2021.2 package somehow made it onto the [archive](https://anaconda.org/conda-forge/pyopencl), when, in reality, I'm still working on that package: https://github.com/conda-forge/pyopencl-feedstock/pull/64. I suspect, but don't know, that these uploads may have been caused by my mistakenly pushing to a branch of the feedstock at first: https://github.com/conda-forge/pyopencl-feedstock/pull/63 (Sorry!). I closed that PR right away, but I guess that may not have prevented damage from being done.

The packages themselves may be mostly fine, however 2021.2 also had a [bug](https://github.com/inducer/pyopencl/pull/474) that caused me to "yank" the release on the package index: https://pypi.org/project/pyopencl/#history. These packages should not be in the wild.

  ping @conda-forge/pyopencl