### PR TITLE
Marked xeus 1.0.2 as broken

### DIFF
--- a/broken/xeus.txt
+++ b/broken/xeus.txt
@@ -1,0 +1,6 @@
+win-64/xeus-1.0.2-h4324990_0.tar.bz2
+linux-aarch64/xeus-1.0.2-he593ebb_0.tar.bz2
+osx-arm64/xeus-1.0.2-h3212551_0.tar.bz2
+osx-64/xeus-1.0.2-hf09c4ce_0.tar.bz2
+linux-ppc64le/xeus-1.0.2-h1916c12_0.tar.bz2
+linux-64/xeus-1.0.2-h7d0c39e_0.tar.bz2


### PR DESCRIPTION
The library binary version is wrong, this breaks downstream packages which cannot find the xeus library anymore.