### PR TITLE
move all non-shared-builds of lemon to broken

### DIFF
--- a/broken/lemon-non-shared.txt
+++ b/broken/lemon-non-shared.txt
@@ -1,0 +1,16 @@
+linux-64/lemon-1.3.1-0.tar.bz2
+linux-64/lemon-1.3.1-1.tar.bz2
+linux-64/lemon-1.3.1-h338f22d_1.tar.bz2
+osx-64/lemon-1.3.1-0.tar.bz2
+osx-64/lemon-1.3.1-1.tar.bz2
+osx-64/lemon-1.3.1-h338f22d_1.tar.bz2
+win-32/lemon-1.3.1-vc14_0.tar.bz2
+win-32/lemon-1.3.1-vc14_1.tar.bz2
+win-32/lemon-1.3.1-vc9_0.tar.bz2
+win-32/lemon-1.3.1-vc9_1.tar.bz2
+win-64/lemon-1.3.1-h8ca70c0_1.tar.bz2
+win-64/lemon-1.3.1-h8fccee9_1.tar.bz2
+win-64/lemon-1.3.1-vc14_0.tar.bz2
+win-64/lemon-1.3.1-vc14_1.tar.bz2
+win-64/lemon-1.3.1-vc9_0.tar.bz2
+win-64/lemon-1.3.1-vc9_1.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

All builds prior to the `_2` (linux, osx), and `_3` (win) were static builds in lemon. This means they were useful in context of building other packages. Currently [the solver seems to pick up](https://github.com/conda-forge/lemon-feedstock/issues/23) the non-shared versions of this library when installing vigra (afaik the only downstream dependency of lemon).

So - I don't think there will be any negative side effects to removing the non-shared libs here.

I'm not sure if this qualifies to adding the `broken` label. (I probably would remove main and add `static_lib` or something like this).


Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.


ping @conda-forge/lemon

<!--
For example if you are trying to mark a `foo` conda package as broken.

  

-->
