### PR TITLE
mark galsim 2.3.2 build 0 broken due to wrong library IDs

### DIFF
--- a/broken/galsim.txt
+++ b/broken/galsim.txt
@@ -1,0 +1,6 @@
+osx-arm64/galsim-2.3.2-py39h2ec83ff_0.tar.bz2
+osx-arm64/galsim-2.3.2-py38h384881f_0.tar.bz2
+osx-64/galsim-2.3.2-py39h9186725_0.tar.bz2
+osx-64/galsim-2.3.2-py38h576f502_0.tar.bz2
+osx-64/galsim-2.3.2-py37h47425da_0.tar.bz2
+osx-64/galsim-2.3.2-py36hb00eb4f_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

For w/e reason, the library ID in these builds is wrong and causes linking errors downstream. See issue https://github.com/conda-forge/galsim-feedstock/issues/35

A fix was pushed here https://github.com/conda-forge/galsim-feedstock/pull/37 while upstream is working on the issue.

cc @conda-forge/galsim 

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
