### PR TITLE
remove win-64/libkml-1.3.0-h9859afa_1013.tar.bz2

### DIFF
--- a/broken/libkml.txt
+++ b/broken/libkml.txt
@@ -1,0 +1,1 @@
+win-64/libkml-1.3.0-h9859afa_1013.tar.bz2


### PR DESCRIPTION
This one was broken on Windows. The next build number is fixed but it would be nice to prevent users from easily installing this one. xref.: https://github.com/conda-forge/gdal-feedstock/pull/508