### PR TITLE
Remove build 0 of unix platforms for polyagamma v1.3.2b3

### DIFF
--- a/broken/polyagamma.txt
+++ b/broken/polyagamma.txt
@@ -1,0 +1,8 @@
+linux-64/polyagamma-1.3.2b3-py38h497a2fe_0.tar.bz2
+linux-64/polyagamma-1.3.2b3-py36h8f6f2f9_0.tar.bz2
+linux-64/polyagamma-1.3.2b3-py37h5e8e339_0.tar.bz2
+linux-64/polyagamma-1.3.2b3-py39h3811e60_0.tar.bz2
+osx-64/polyagamma-1.3.2b3-py38h96a0964_0.tar.bz2
+osx-64/polyagamma-1.3.2b3-py36hfa26744_0.tar.bz2
+osx-64/polyagamma-1.3.2b3-py39h89e85a6_0.tar.bz2
+osx-64/polyagamma-1.3.2b3-py37h271585c_0.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

Build 0 of version 1.3.2b3 of polyagamma is broken for Unix systems as outline in https://github.com/conda-forge/polyagamma-feedstock/issues/1 . Build 1 was issued [shortly after](https://github.com/conda-forge/polyagamma-feedstock/pull/2) so I think build 0 should be pulled.

Im the maintainer of the feedstock.