### PR TITLE
Removing first build because broken

### DIFF
--- a/broken/broken_puma_builds.txt
+++ b/broken/broken_puma_builds.txt
@@ -1,0 +1,8 @@
+osx-64/puma-3.0.0-py37hfb6df98_0.tar.bz2
+osx-64/puma-3.0.0-py38h1078ab5_0.tar.bz2
+osx-64/puma-3.0.0-py39h7812578_0.tar.bz2
+osx-64/puma-3.0.0-py36h5403bd3_0.tar.bz2
+linux-64/puma-3.0.0-py36hefa481c_0.tar.bz2
+linux-64/puma-3.0.0-py39h3d6a961_0.tar.bz2
+linux-64/puma-3.0.0-py37hf0709b1_0.tar.bz2
+linux-64/puma-3.0.0-py38haeea490_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

The first build of this package is broken for a couple of reasons: 
- scikit-image is broken due to incorrect import of pooch (need a specific version)
- several hot fixes have been performed on the puma/pumapy package
