### PR TITLE
Mark noarch Prophet package as broken

### DIFF
--- a/broken/prophet.txt
+++ b/broken/prophet.txt
@@ -1,0 +1,1 @@
+noarch/prophet-1.0.1-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
The initial noarch version of the Prophet package is broken, throwing the error `AttributeError: 'StanModel' object has no attribute 'fit_class'`.
See https://github.com/conda-forge/prophet-feedstock/issues/1 for a description of the issues.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

ping @conda-forge/prophet

