### PR TITLE
Mark nbconvert 6.2.0rc0 on main as broken

### DIFF
--- a/broken/nbconvert-6.2.0rc0.txt
+++ b/broken/nbconvert-6.2.0rc0.txt
@@ -1,0 +1,17 @@
+win-64/nbconvert-6.2.0rc0-py38haa244fe_0.tar.bz2
+win-64/nbconvert-6.2.0rc0-py37h03978a9_0.tar.bz2
+win-64/nbconvert-6.2.0rc0-py39hcbf5309_0.tar.bz2
+osx-arm64/nbconvert-6.2.0rc0-py38h10201cd_0.tar.bz2
+linux-ppc64le/nbconvert-6.2.0rc0-py37hadc05a3_0.tar.bz2
+osx-64/nbconvert-6.2.0rc0-py37h5186d4c_0.tar.bz2
+osx-arm64/nbconvert-6.2.0rc0-py39h2804cbe_0.tar.bz2
+osx-64/nbconvert-6.2.0rc0-py37hf985489_0.tar.bz2
+osx-64/nbconvert-6.2.0rc0-py39h6e9494a_0.tar.bz2
+osx-64/nbconvert-6.2.0rc0-py38h50d1736_0.tar.bz2
+linux-ppc64le/nbconvert-6.2.0rc0-py37h35e4cab_0.tar.bz2
+linux-ppc64le/nbconvert-6.2.0rc0-py38hf8b3453_0.tar.bz2
+linux-ppc64le/nbconvert-6.2.0rc0-py39hc1b9086_0.tar.bz2
+linux-64/nbconvert-6.2.0rc0-py39hf3d152e_0.tar.bz2
+linux-64/nbconvert-6.2.0rc0-py38h578d9bd_0.tar.bz2
+linux-64/nbconvert-6.2.0rc0-py37h9c2f6ca_0.tar.bz2
+linux-64/nbconvert-6.2.0rc0-py37h89c1867_0.tar.bz

--- a/broken/nbconvert-6.2.0rc0.txt
+++ b/broken/nbconvert-6.2.0rc0.txt
@@ -14,4 +14,4 @@ linux-ppc64le/nbconvert-6.2.0rc0-py39hc1b9086_0.tar.bz2
 linux-64/nbconvert-6.2.0rc0-py39hf3d152e_0.tar.bz2
 linux-64/nbconvert-6.2.0rc0-py38h578d9bd_0.tar.bz2
 linux-64/nbconvert-6.2.0rc0-py37h9c2f6ca_0.tar.bz2
-linux-64/nbconvert-6.2.0rc0-py37h89c1867_0.tar.bz
+linux-64/nbconvert-6.2.0rc0-py37h89c1867_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

We released nbconvert 6.2.0rc0 in the main channel instead of using the rc label by mistake. See https://github.com/conda-forge/nbconvert-feedstock/issues/58#issuecomment-920274460 and the file list at https://anaconda.org/conda-forge/nbconvert/files


Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.


ping @conda-forge/nbconvert

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
