### PR TITLE
remove curl 7.79.0

### DIFF
--- a/broken/curl.txt
+++ b/broken/curl.txt
@@ -1,0 +1,6 @@
+linux-64/libcurl-7.79.0-h2574ce0_0.tar.bz2
+linux-aarch64/libcurl-7.79.0-hcafe9da_0.tar.bz2
+linux-ppc64le/libcurl-7.79.0-he415e40_0.tar.bz2
+win-64/libcurl-7.79.0-h789b8ee_0.tar.bz2
+osx-arm64/libcurl-7.79.0-h8fe1914_0.tar.bz2
+osx-64/libcurl-7.79.0-hf45b732_0.tar.bz2


### PR DESCRIPTION
This bug https://github.com/curl/curl/issues/7738 is solved in 7.79.1 and that one will be in the channel soon (https://github.com/conda-forge/curl-feedstock/pull/96) but we need to remove the 7.79.0 to avoid headaches.