### PR TITLE
Mark uwsift 1.2.0 py36 packages as broken

### DIFF
--- a/broken/uwsift.txt
+++ b/broken/uwsift.txt
@@ -1,0 +1,3 @@
+win-64/uwsift-1.2.0-py36ha15d459_0.tar.bz2
+osx-64/uwsift-1.2.0-py36h79c6626_0.tar.bz2
+linux-64/uwsift-1.2.0-py36h5fab9bb_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

### Description

The newest release of the uwsift package was built for Python 3.6+, but does not actually support Python 3.6. It is **not** noarch so there are actual packages for the Python 3.6 builds. This was a mistake on my part as I was using a feature only supported by Python 3.7+ but didn't realize it and didn't bump the version requirement in the new version PR.

Since there are actual packages that do not work I considered this a broken packages case. If this is something that can be updated in just metadata then let me know. I've already made the PR to fix the version limit in the feedstock. Thanks.

New release with bad version limit:
https://github.com/conda-forge/uwsift-feedstock/pull/10

New limit:
https://github.com/conda-forge/uwsift-feedstock/pull/11