### PR TITLE
Broken: python=3.10 w/o conda symlink workaround

### DIFF
--- a/broken/python-3.10-without-conda-symlink-workaround.txt
+++ b/broken/python-3.10-without-conda-symlink-workaround.txt
@@ -1,0 +1,10 @@
+linux-64/python-3.10.0-h543edf9_0_cpython.tar.bz2
+linux-64/python-3.10.0-h62f1059_0_cpython.tar.bz2
+linux-aarch64/python-3.10.0-h2265c99_0_cpython.tar.bz2
+linux-aarch64/python-3.10.0-hc23e7ad_0_cpython.tar.bz2
+linux-ppc64le/python-3.10.0-h144377c_0_cpython.tar.bz2
+linux-ppc64le/python-3.10.0-h3e5bdd0_0_cpython.tar.bz2
+osx-64/python-3.10.0-h1248fe1_0_cpython.tar.bz2
+osx-64/python-3.10.0-h38b4d05_0_cpython.tar.bz2
+osx-arm64/python-3.10.0-h43b31ca_0_cpython.tar.bz2
+osx-arm64/python-3.10.0-h70c1b39_0_cpython.tar.bz2


### PR DESCRIPTION
ref:
  - https://github.com/conda-forge/python-feedstock/pull/511

cc @conda-forge/python

The first builds of `python=3.10` did not carry the workaround for https://github.com/conda/conda/issues/10969 added in the PR referenced above.

----
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
