### PR TITLE
add lua osx-arm64 to broken

### DIFF
--- a/broken/lua.txt
+++ b/broken/lua.txt
@@ -1,0 +1,1 @@
+osx-arm64/lua-5.4.3-h0227c9b_1.tar.bz2


### PR DESCRIPTION
the first osx-arm64 build was built with CC_FOR_BUILD which resulted in a dylib for x64

ref https://github.com/conda-forge/lua-feedstock/issues/45