### PR TITLE
ENH cronjob for repodata patching

### DIFF
--- a/.github/workflows/repodata_patching.yml
+++ b/.github/workflows/repodata_patching.yml
@@ -1,0 +1,52 @@
+name: repodata_patching
+
+on:
+  schedule:
+    - cron:  '0 0 * * 0'
+  workflow_dispatch: null
+
+jobs:
+  repodata_patching:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prevent multiple jobs running in parallel
+        id: conversion_lock
+        uses: beckermr/turnstyle-python@v1
+        with:
+          abort-after-seconds: 3
+          poll-interval-seconds: 2
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - uses: actions/checkout@v2
+        # outcome is evaluated before continue-on-error above
+        if: steps.conversion_lock.outcome == 'success'
+
+      - uses: conda-incubator/setup-miniconda@v2
+        if: steps.conversion_lock.outcome == 'success'
+        with:
+          activate-environment: cf
+          environment-file: environment.yml
+          auto-activate-base: true
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+
+      - name: Generate token
+        if: steps.conversion_lock.outcome == 'success'
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.CF_CURATOR_APP_ID }}
+          private_key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}
+
+      - name: patch repodata
+        if: steps.conversion_lock.outcome == 'success'
+        shell: bash -l {0}
+        run: |
+            conda activate cf
+            git config --global user.name "conda-forge-admin"
+            git config --global user.email "pelson.pub+conda-forge@gmail.com"
+            git config --global pull.rebase false
+            python update_repodata_patches.py
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/update_repodata_patches.py
+++ b/update_repodata_patches.py
@@ -1,0 +1,93 @@
+import sys
+import subprocess
+import os
+import tempfile
+import github
+import datetime
+
+
+def _commit_to_patches(tmpdir):
+    subprocess.check_call(
+        "git reset --hard HEAD",
+        cwd=os.path.join(tmpdir, "conda-forge-repodata-patches-feedstock"),
+        shell=True,
+    )
+
+    subprocess.check_call(
+        "git commit --allow-empty -am 'resync repo data for weekly cron-job'",
+        cwd=os.path.join(tmpdir, "conda-forge-repodata-patches-feedstock"),
+        shell=True,
+    )
+
+    subprocess.check_call(
+        "git push",
+        cwd=os.path.join(tmpdir, "conda-forge-repodata-patches-feedstock"),
+        shell=True,
+    )
+
+
+def _post_issue_with_diff(diff):
+    msg = """\
+Hi! Our weekly job found a non-zero repodata patch diff:
+
+<details>
+
+```
+%s
+```
+
+</details>
+""" % diff
+
+    dstr = datetime.date.today().strftime("%Y-%m-%d")
+    gh = github.Github(os.environ['GITHUB_TOKEN'])
+    repo = gh.get_repo("conda-forge/conda-forge-repodata-patches-feedstock")
+    repo.create_issue(
+        "[%s] non-zero repodata patch diff" % dstr,
+        body=msg,
+    )
+
+
+def update_repodata_patches(dry_run):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.check_call(
+            "git clone https://github.com/conda-forge/"
+            "conda-forge-repodata-patches-feedstock.git",
+            cwd=tmpdir,
+            shell=True,
+        )
+
+        subprocess.check_call(
+            "git remote set-url --push origin "
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/conda-forge/"
+            "conda-forge-repodata-patches-feedstock.git",
+            cwd=os.path.join(tmpdir, "conda-forge-repodata-patches-feedstock"),
+            shell=True,
+        )
+
+        d = subprocess.check_output(
+            "python show_diff.py",
+            cwd=os.path.join(
+                tmpdir,
+                "conda-forge-repodata-patches-feedstock",
+                "recipe"
+            ),
+            shell=True,
+        ).decode("utf-8")
+
+        if len(d) > 0:
+            print("diff:\n" + d, flush=True)
+            if not dry_run:
+                _post_issue_with_diff(d)
+                _commit_to_patches(tmpdir)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        raise RuntimeError("Need 0 or 1 arguments")
+    if len(sys.argv) == 2 and sys.argv[1] == '--dry-run':
+        dry_run = True
+    else:
+        dry_run = False
+
+    update_repodata_patches(dry_run)


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [ ] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [ ] Added a description of the problem with the package in the PR description.
* [ ] Added links to any relevant issues/PRs in the PR description.
* [ ] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
