### PR TITLE
Mark `dotnet-sdk` 6.0.100 build 0 as broken

### DIFF
--- a/broken/dotnet-sdk.txt
+++ b/broken/dotnet-sdk.txt
@@ -1,0 +1,5 @@
+win-64/dotnet-sdk-6.0.100-h2d74725_0.tar.bz2
+osx-64/dotnet-sdk-6.0.100-ha205975_0.tar.bz2
+osx-arm64/dotnet-sdk-6.0.100-hd68eb72_0.tar.bz2
+linux-aarch64/dotnet-sdk-6.0.100-h25a8a10_0.tar.bz2
+linux-64/dotnet-sdk-6.0.100-h73ebe80_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

----

.NET6 added a new sub-folder `sdk-manifests` which wasn't present in .NET5. This new folder wasn't being copied over in the build so the SDK apparently doesn't work for building .NET apps :(

This was brought to our attention and resolved in https://github.com/conda-forge/dotnet-feedstock/pull/45

Since build 0 won't actually work (IIUC) for building .NET apps it should be yanked to avoid others running into the same issue as seen in https://github.com/pythonnet/clr-loader/issues/19 
