### PR TITLE
Mark Pennylane as broken

### DIFF
--- a/broken/pennylane-lightning.txt
+++ b/broken/pennylane-lightning.txt
@@ -1,0 +1,12 @@
+linux-64/pennylane-lightning-0.19.0-py39hf1b4069_1.tar.bz2
+linux-64/pennylane-lightning-0.19.0-py38hd3aa62d_1.tar.bz2
+linux-64/pennylane-lightning-0.19.0-py310he3072ea_1.tar.bz2
+linux-64/pennylane-lightning-0.19.0-py37h27983e4_1.tar.bz2
+osx-64/pennylane-lightning-0.19.0-py39hb932247_1.tar.bz2
+osx-64/pennylane-lightning-0.19.0-py38hf059507_1.tar.bz2
+osx-64/pennylane-lightning-0.19.0-py310h7e58e96_1.tar.bz2
+osx-64/pennylane-lightning-0.19.0-py37h6452af0_1.tar.bz2
+win-64/pennylane-lightning-0.19.0-py310hd611064_1.tar.bz2
+win-64/pennylane-lightning-0.19.0-py39hcbbd332_1.tar.bz2
+win-64/pennylane-lightning-0.19.0-py37h008bc43_1.tar.bz2
+win-64/pennylane-lightning-0.19.0-py38h622d22c_1.tar.bz2

--- a/broken/pennylane.txt
+++ b/broken/pennylane.txt
@@ -1,0 +1,2 @@
+noarch/pennylane-0.19.0-pyhd8ed1ab_0.tar.bz2
+noarch/pennylane-0.19.0-pyhd8ed1ab_1.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

-->

* I'm the owner of both feedstocks
* The packages have a circular dependency and where added without it. Since they both built correctly now, I added the dependency and am removing the initial packages again.
* Ref https://github.com/conda-forge/staged-recipes/pull/16958#issuecomment-970440205
* The packages were only added yesterday.