### PR TITLE
mark broken packages for rdt and sdmetrics

### DIFF
--- a/broken/rdt_and_sdmetrics.txt
+++ b/broken/rdt_and_sdmetrics.txt
@@ -1,0 +1,2 @@
+noarch/rdt-0.6.1-pyhd8ed1ab_0.tar.bz2
+noarch/sdmetrics-0.4.0-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [ ] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
The two packages listed failed to install for python 3.9. This is because one of the packages didn't update the supported python versions when the new package version was merged (https://github.com/conda-forge/rdt-feedstock/pull/2/files). The other didn't appropriately update an upper range for one of its dependencies. Both of these issues were resolved by the following PRs
- https://github.com/conda-forge/sdmetrics-feedstock/pull/1
- https://github.com/conda-forge/rdt-feedstock/pull/3
There are now files uploaded to anaconda with the build number 1 for each of these that work.