### PR TITLE
Mark mesalib with gl builds as broken

### DIFF
--- a/broken/mesalib_21_with_gl.txt
+++ b/broken/mesalib_21_with_gl.txt
@@ -1,0 +1,13 @@
+linux-aarch64/mesalib-21.2.5-h0bd06be_2.tar.bz2
+linux-ppc64le/mesalib-21.2.5-ha5911c8_2.tar.bz2
+osx-arm64/mesalib-21.2.5-h25af579_2.tar.bz2
+osx-64/mesalib-21.2.5-h2df1e00_2.tar.bz2
+linux-64/mesalib-21.2.5-h0e4506f_2.tar.bz2
+linux-aarch64/mesalib-21.2.5-h0bd06be_1.tar.bz2
+linux-ppc64le/mesalib-21.2.5-ha5911c8_1.tar.bz2
+osx-64/mesalib-21.2.5-h2df1e00_1.tar.bz2
+linux-64/mesalib-21.2.5-h0e4506f_1.tar.bz2
+linux-aarch64/mesalib-21.2.5-h0bd06be_0.tar.bz2
+linux-ppc64le/mesalib-21.2.5-ha5911c8_0.tar.bz2
+osx-64/mesalib-21.2.5-h2df1e00_0.tar.bz2
+linux-64/mesalib-21.2.5-h0e4506f_0.tar.bz2


### PR DESCRIPTION
These packages were accentally built with `GL.so` which overrides the user's system GL.so file causing all opengl to be software rendered. This is almost certainly not what people want when they are trying to use scientific visualization software that depends on GL.so

See https://github.com/conda-forge/mesalib-feedstock/pull/40#issuecomment-984808054
And an issue raised by a user: https://github.com/conda-forge/mesalib-feedstock/issues/16#issuecomment-984504934

@conda-forge/mesalib do you support marking all 21 builds as broken?

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [ ] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [ ] Added a description of the problem with the package in the PR description.
* [ ] Added links to any relevant issues/PRs in the PR description.
* [ ] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
