### PR TITLE
Make mistune-2.0.0_0 broken

### DIFF
--- a/broken/mistune-2.0.0.txt
+++ b/broken/mistune-2.0.0.txt
@@ -1,0 +1,1 @@
+noarch/mistune-2.0.0-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

`mistune 2.0.0` dropped recently, and has a few thousand downloads.

A key downstream, `nbconvert`, does not support `mistune 2.0.0`:
- it has correct mistune pin starting from https://github.com/conda-forge/nbconvert-feedstock/pull/54 but there are hundreds of older builds that are broken

This is probably blocked by a review by @conda-forge/mistune of:
- https://github.com/conda-forge/mistune-feedstock/pull/23 which adds `run_constrained` for nbconvert to align with the above pin, 
  - it is currently unsatisfiable, but...
    - would allow for a future release to be relax its pin https://github.com/jupyter/nbconvert/issues/1685