### PR TITLE
Create kaldi_broken

### DIFF
--- a/broken/kaldi_broken
+++ b/broken/kaldi_broken
@@ -1,0 +1,8 @@
+osx-64/kaldi-cpu-5.5.992-cpu_py39he781eb1_4.tar.bz2
+osx-arm64/kaldi-cpu-5.5.992-cpu_py39hd610c6a_4.tar.bz2
+win-64/kaldi-cpu-5.5.992-cpu_py39hf9c7e24_4.tar.bz2
+linux-64/kaldi-cpu-5.5.992-cpu_py38h718b53a_4.tar.bz2
+linux-64/kaldi-cpu-5.5.992-cpu_h718b53a_6.tar.bz2
+win-64/kaldi-cpu-5.5.992-cpu_hf9c7e24_6.tar.bz2
+osx-arm64/kaldi-cpu-5.5.992-cpu_hd610c6a_6.tar.bz2
+osx-64/kaldi-cpu-5.5.992-cpu_he781eb1_6.tar.bz2

--- a/broken/kaldi_broken.txt
+++ b/broken/kaldi_broken.txt
@@ -2,7 +2,3 @@ osx-64/kaldi-cpu-5.5.992-cpu_py39he781eb1_4.tar.bz2
 osx-arm64/kaldi-cpu-5.5.992-cpu_py39hd610c6a_4.tar.bz2
 win-64/kaldi-cpu-5.5.992-cpu_py39hf9c7e24_4.tar.bz2
 linux-64/kaldi-cpu-5.5.992-cpu_py38h718b53a_4.tar.bz2
-linux-64/kaldi-cpu-5.5.992-cpu_h718b53a_6.tar.bz2
-win-64/kaldi-cpu-5.5.992-cpu_hf9c7e24_6.tar.bz2
-osx-arm64/kaldi-cpu-5.5.992-cpu_hd610c6a_6.tar.bz2
-osx-64/kaldi-cpu-5.5.992-cpu_he781eb1_6.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

I'm having an issue where `conda install -n test kaldi-cpu` (https://github.com/conda-forge/kaldi-feedstock) is not correctly installing the latest builds (it's installing _4 instead of the later _6 or _7).  The _4 package doesn't actually seem to install anything, it just has a conda-meta folder.  I must have messed something up in the process of trying to get separate cpu and cuda packages for Kaldi working.  I've tested installing both the _6 and 7 directly and they correctly install files.  It's possible that something about the subpackages is misconfigured, but I tried to model it as close to the pytorch-cpu-feedstock as possible.