### PR TITLE
Mark current orange3 packages for python310 as broken

### DIFF
--- a/broken/orange3.txt
+++ b/broken/orange3.txt
@@ -1,0 +1,6 @@
+win-64/orange3-3.31.0-py310hf5e1058_2.tar.bz2
+osx-64/orange3-3.31.0-py310hdd25497_2.tar.bz2
+linux-64/orange3-3.31.0-py310hb5077e9_2.tar.bz2
+win-64/orange3-3.31.0-py310hf5e1058_1.tar.bz2
+osx-64/orange3-3.31.0-py310hdd25497_1.tar.bz2
+linux-64/orange3-3.31.0-py310hb5077e9_1.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

Our team merged conda-forge/orange3-feedstock#107 (Rebuild for python310). Unfortunately, there are problems we did not foresee. To support Python 3.10 `orange3` needs both:
1. PyQt >= 5.15 or corresponding workarounds in code
2. Fixes for deprecated implicit casts to `int` in biolab/orange3

Some discussion about the problem: biolab/orange3#5748

`orange3=3.31.0` thus can not be fixed to support Python 3.10. We thus kindly ask the core team to mark the corresponding packages as broken and we will revert conda-forge/orange3-feedstock#107 for the time being.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
