### PR TITLE
Mark fmt-8.1.0 as broken

### DIFF
--- a/broken/fmt.txt
+++ b/broken/fmt.txt
@@ -1,0 +1,6 @@
+linux-64/fmt-8.1.0-h4bd325d_0.tar.bz2
+linux-aarch64/fmt-8.1.0-hd62202e_0.tar.bz2
+linux-ppc64le/fmt-8.1.0-h2acdbc0_0.tar.bz2
+osx-64/fmt-8.1.0-h940c156_0.tar.bz2
+osx-arm64/fmt-8.1.0-hc021e02_0.tar.bz2
+win-64/fmt-8.1.0-h5362a0b_0.tar.bz2


### PR DESCRIPTION
fmt-8.1.0 introduced a breaking ABI change. This breaks packages that
were built against fmt-8.0.1 when they use fmt-8.1.0 at runtime.

The issue has been reported upstream and a patch is waiting to be
merged. We might create a patched 8.1.0 build or wait for 8.1.1; the
relevant discussion is at
https://github.com/conda-forge/fmt-feedstock/pull/28 and
https://github.com/fmtlib/fmt/pull/2696.

An alternative here would be to patch the repodata and tell the <8.1.0
build to use !=8.1.0_0. However, it does not seem to be the correct
approach to me to exclude a single build with a constraint.