### PR TITLE
Remove filelock 3.4.2 build 0

### DIFF
--- a/broken/filelock.txt
+++ b/broken/filelock.txt
@@ -1,0 +1,1 @@
+noarch/filelock-3.4.2-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
It should not support Python 3.6, see https://github.com/conda-forge/filelock-feedstock/issues/30.
