### PR TITLE
removing julia 1.8.0 dev uploads from label main

### DIFF
--- a/broken/julia.txt
+++ b/broken/julia.txt
@@ -1,1 +1,2 @@
 linux-64/julia-1.8.0.dev.1258-h989b2f6_0.tar.bz2
+osx-64/julia-1.8.0.dev.1258-h132cb31_0.tar.bz2

--- a/broken/julia.txt
+++ b/broken/julia.txt
@@ -1,0 +1,1 @@
+linux-64/julia-1.8.0.dev.1258-h989b2f6_0.tar.bz2


### PR DESCRIPTION
These two packages accidentally got uploaded with label main instead of label julia_dev. I have since rerendered the branch to correctly point to julia_dev. Please remove this in the meanwhile. Thank you and sorry about this messup.

Relevant PR: https://github.com/conda-forge/julia-feedstock/pull/181

Relevant branch: https://github.com/conda-forge/julia-feedstock/tree/dev

cc @conda-forge/julia (especially @mkitti)


---

More details about how the problem happened:

There was a disconnect between the PR and the dev branch. I mistakenly created the dev branch without rerendering, insteading relying on rerendering in the PR. So the rerendering calls in the PR didn't change the files inside .ci_support. I could have avoided this mess if I followed the description on conda-forge knowledge base more closely. Again, sorry about this mistake and hopefully you will help us take these two files out of circulation asap. Thank you!  

---

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
