### PR TITLE
Mark nbclient 0.5.10 build 0 as broken

### DIFF
--- a/broken/nbclient.txt
+++ b/broken/nbclient.txt
@@ -1,0 +1,1 @@
+noarch/nbclient-0.5.10-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [ ] Pinged the team for the package for their input.

Lower Python pin should follow nbclient 0.5.10 on PyPI.
See https://github.com/jupyter/nbclient/issues/194