### PR TITLE
Mark flake8 4.0.1 build 0 as broken

### DIFF
--- a/broken/flake8.txt
+++ b/broken/flake8.txt
@@ -1,0 +1,1 @@
+noarch/flake8-4.0.1-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

----

Problem

* That build doesn't require the right version of `importlib-metadata`, which is `<4.3` for Python 3.7. Build 1 solved that problem.
* This problem was identified by @xhochy in https://github.com/conda-forge/spyder-terminal-feedstock/pull/25#issuecomment-1003160831, so I'm making the PR he thinks is necessary to solve it.
* Pinging @conda-forge/flake8 about this.

