### PR TITLE
Mark sphinx 4.4.0 build 0 as broken

### DIFF
--- a/broken/sphinx.txt
+++ b/broken/sphinx.txt
@@ -1,0 +1,1 @@
+noarch/sphinx-4.4.0-pyh6c4a22f_0.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

----

* Sphinx 4.4.0 depends on `importlib-metadata >=4.4`, but that dependency was added in build 1 (see https://github.com/conda-forge/sphinx-feedstock/pull/116). So, build 0 is broken and needs to be marked as such.
* Due to this problem, conda/mamba can't resolve the right constraints when you need packages that depend on different versions of `importlib-metadata`, such as flake8 4.0.1 (`importlib-metadata < 4.3`) and Sphinx 4.4.0.
* This was detected in  conda-forge/spyder-feedstock#123
* Pinging @conda-forge/sphinx about this.