### PR TITLE
Mark message-ix 1.0.0 as broken

### DIFF
--- a/broken/message-ix.txt
+++ b/broken/message-ix.txt
@@ -1,0 +1,8 @@
+noarch/message-ix-1.0.0-0.tar.bz2
+noarch/message-ix-1.0.0-1.tar.bz2
+linux-64/message-ix-1.0.0-2.tar.bz2
+win-64/message-ix-1.0.0-2.tar.bz2
+osx-64/message-ix-1.0.0-2.tar.bz2
+linux-64/message-ix-1.0.0-3.tar.bz2
+win-64/message-ix-1.0.0-3.tar.bz2
+osx-64/message-ix-1.0.0-3.tar.bz2


### PR DESCRIPTION
Conda doesn't install the latest message-ix package on windows-latest by default (current version 3.4.0), but rather installs message-ix version 1.0.0, please see [here](https://github.com/iiasa/message_ix/runs/5001443802?check_suite_focus=true) and the corresponding workflow step [here](https://github.com/iiasa/message_ix/blob/main/.github/workflows/conda.yaml#L71). Relevant PR https://github.com/iiasa/message_ix/pull/541.

Ping @conda-forge/message-ix 

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.


