### PR TITLE
mark shared windows build of abseil-cpp as broken

### DIFF
--- a/broken/abseil-cpp.txt
+++ b/broken/abseil-cpp.txt
@@ -1,0 +1,1 @@
+win-64/abseil-cpp-20211102.0-h0e60522_1.tar.bz2


### PR DESCRIPTION
The new shared windows builds of https://github.com/conda-forge/abseil-cpp-feedstock/pull/25 caused some issues for arrow-cpp; mark them broken to unjam other people's CIs (and then figure out what went wrong and how to fix it).