### PR TITLE
Mark broken OpenFF Toolkit builds as broken

### DIFF
--- a/broken/openff-toolkit-base.txt
+++ b/broken/openff-toolkit-base.txt
@@ -1,0 +1,2 @@
+noarch/openff-toolkit-base-0.10.1-pyhd8ed1ab_0.tar.bz2
+noarch/openff-toolkit-base-0.10.2-pyhd8ed1ab_0.tar.bz2

--- a/broken/openff-toolkit-examples.txt
+++ b/broken/openff-toolkit-examples.txt
@@ -1,0 +1,2 @@
+noarch/openff-toolkit-examples-0.10.2-pyhd8ed1ab_0.tar.bz2
+noarch/openff-toolkit-examples-0.10.1-pyhd8ed1ab_0.tar.bz2

--- a/broken/openff-toolkit.txt
+++ b/broken/openff-toolkit.txt
@@ -1,0 +1,2 @@
+noarch/openff-toolkit-0.10.2-pyhd8ed1ab_0.tar.bz2
+noarch/openff-toolkit-0.10.1-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!


Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata pacthes to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.
-->
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [ ] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

Hi core team,

We recently [identified a critical bug ](https://github.com/openforcefield/openff-toolkit/issues/1199)in one of our packages that make it into two releases (0.10.1 and 0.10.2). It results in molecular models of water being parametrized wildly inaccurately, which is pretty important in our user's workflows. We [fixed it](https://github.com/openforcefield/openff-toolkit/pull/1200) and released a new version (0.10.3), which has been [online for a couple of days](https://anaconda.org/conda-forge/openff-toolkit/files). The bug as critical enough that it warrants marking the old packages as broken - we don't want it to be possible for users to pull them down, even at the cost of diminished environment reproducibility, and we expect everybody to be able to pull down the new release (no dep changes in the [new version](https://github.com/conda-forge/openff-toolkit-feedstock/pull/17/files)). Since this is a matter of the software itself and not a packaging headache, we would like it to be labeled as broken instead of patching the repodata (I'm not sure how that would help, to be honest).

The feedstock uses `outputs:` and [is split](https://github.com/conda-forge/openff-toolkit-feedstock/blob/e55bc3e872ce5ce242947fb78226f4f60af54cc0/recipe/meta.yaml#L16) into three packages, each following the same versioning. - I think including each of them is the way to go but I'm happy to fix it if I'm wrong.