### PR TITLE
OpenMM packages for Mac are broken

### DIFF
--- a/broken/openmm.txt
+++ b/broken/openmm.txt
@@ -1,0 +1,16 @@
+osx-arm64/openmm-7.7.0-py310hdca8ec0_1_khronos.tar.bz2
+osx-arm64/openmm-7.7.0-py38h499797b_1_khronos.tar.bz2
+osx-arm64/openmm-7.7.0-py310h147248c_1_apple.tar.bz2
+osx-arm64/openmm-7.7.0-py38h2fcb312_1_apple.tar.bz2
+osx-64/openmm-7.7.0-py37h3be4b2a_1_apple.tar.bz2
+osx-arm64/openmm-7.7.0-py39h83e8822_1_khronos.tar.bz2
+osx-64/openmm-7.7.0-py38h8499687_1_apple.tar.bz2
+osx-64/openmm-7.7.0-py37h2a9eceb_1_khronos.tar.bz2
+osx-64/openmm-7.7.0-py39h807f3c3_1_khronos.tar.bz2
+osx-arm64/openmm-7.7.0-py39hbfad222_1_apple.tar.bz2
+osx-64/openmm-7.7.0-py37hea54a85_1_khronos.tar.bz2
+osx-64/openmm-7.7.0-py37h2029789_1_apple.tar.bz2
+osx-64/openmm-7.7.0-py310h52fe9ac_1_apple.tar.bz2
+osx-64/openmm-7.7.0-py38hfab746a_1_khronos.tar.bz2
+osx-64/openmm-7.7.0-py39h8a2e0eb_1_apple.tar.bz2
+osx-64/openmm-7.7.0-py310h5fb6086_1_khronos.tar.bz2


### PR DESCRIPTION
We merged https://github.com/conda-forge/openmm-feedstock/pull/70 two days ago to build Python 3.10 packages for OpenMM.  In addition to building Python 3.10 packages, it also rebuilt the packages for all earlier Python versions.  It appears that all the newly built packages for Mac are broken.  They produce segfaults when anyone tries to use them.  We don't understand why, but the old packages work correctly and the new packages built from the same tag fail.  Presumably this is due to a change to something else in the conda-forge build infrastructure?  See https://github.com/openmm/openmm/issues/3495.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
