### PR TITLE
Mark cross-compiled VOMS binaries as broken

### DIFF
--- a/broken/voms.txt
+++ b/broken/voms.txt
@@ -1,0 +1,6 @@
+osx-arm64/voms-2.1.0rc0-h50daa2a_3.tar.bz2/info/recipe/meta.yaml
+osx-arm64/voms-2.1.0rc0-h633cc78_4.tar.bz2/info/recipe/meta.yaml
+linux-ppc64le/voms-2.1.0rc0-heb2815b_3.tar.bz2/info/recipe/meta.yaml
+linux-ppc64le/voms-2.1.0rc0-h37f2aeb_4.tar.bz2/info/recipe/meta.yaml
+linux-aarch64/voms-2.1.0rc0-hc936626_3.tar.bz2/info/recipe/meta.yaml
+linux-aarch64/voms-2.1.0rc0-h801a2a0_4.tar.bz2/info/recipe/meta.yaml


### PR DESCRIPTION
It seems that gsoap doesn't work correctly when cross-compiling and spits out bizzare SSL errors. Hopefully VOMS won't last too much longer before it can be archived so I'll just switch to native builds (https://github.com/conda-forge/voms-feedstock/pull/11).