### PR TITLE
mark poppler 22.01.0 on win as broken

### DIFF
--- a/broken/poppler.txt
+++ b/broken/poppler.txt
@@ -1,0 +1,2 @@
+win-64/poppler-22.01.0-h24fffdf_1.tar.bz2
+win-64/poppler-22.01.0-h24fffdf_0.tar.bz2


### PR DESCRIPTION
Follow up to https://github.com/conda-forge/poppler-feedstock/pull/125