### PR TITLE
Mark as broken libignition-fuel-tools builds against broken libyaml builds

### DIFF
--- a/broken/libignition-fuel-tools-yaml.txt
+++ b/broken/libignition-fuel-tools-yaml.txt
@@ -1,0 +1,12 @@
+win-64/libignition-fuel-tools7-7.0.0-h98d6f7e_4.tar.bz2
+osx-64/libignition-fuel-tools7-7.0.0-h1699cbd_4.tar.bz2
+osx-arm64/libignition-fuel-tools7-7.0.0-h6f1ad23_4.tar.bz2
+linux-ppc64le/libignition-fuel-tools7-7.0.0-ha9a526a_4.tar.bz2
+linux-aarch64/libignition-fuel-tools7-7.0.0-hb250485_4.tar.bz2
+linux-64/libignition-fuel-tools7-7.0.0-hfaf2eda_4.tar.bz2
+win-64/libignition-fuel-tools4-4.4.0-h98d6f7e_5.tar.bz2
+osx-arm64/libignition-fuel-tools4-4.4.0-h6f1ad23_5.tar.bz2
+osx-64/libignition-fuel-tools4-4.4.0-h1699cbd_5.tar.bz2
+linux-ppc64le/libignition-fuel-tools4-4.4.0-ha9a526a_5.tar.bz2
+linux-aarch64/libignition-fuel-tools4-4.4.0-hb250485_5.tar.bz2
+linux-64/libignition-fuel-tools4-4.4.0-hfaf2eda_5.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->


Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata pacthes to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

fyi @conda-forge/libignition-fuel-tools 


Some time ago there was an unintentionally ABI breakage on yaml, see https://github.com/conda-forge/yaml-feedstock/issues/21 . The resulting package were marked as broken in https://github.com/conda-forge/admin-requests/pull/361, but there was some downstream package that were built against the broken package in a way that caused problems. New builds of those packages were done to avoid the problem in https://github.com/conda-forge/libignition-fuel-tools-feedstock/pull/60 and https://github.com/conda-forge/libignition-fuel-tools-feedstock/pull/61, but the problematic builds were never marked as broken. However, those broken builds are now popping out in https://github.com/conda-forge/gazebo-feedstock/issues/125, so I think it is a good idea to mark them as broken.
