### PR TITLE
Mark Vigra without openexr as broken

### DIFF
--- a/broken/vigra_1030.txt
+++ b/broken/vigra_1030.txt
@@ -1,0 +1,17 @@
+osx-arm64/vigra-1.11.1-py310hb7246df_1030.tar.bz2
+osx-arm64/vigra-1.11.1-py38hf8bd7f9_1030.tar.bz2
+osx-arm64/vigra-1.11.1-py39h9b26c2d_1030.tar.bz2
+osx-64/vigra-1.11.1-py310h2d7e19f_1030.tar.bz2
+osx-64/vigra-1.11.1-py37h50f29fb_1030.tar.bz2
+osx-64/vigra-1.11.1-py37h5af78d1_1030.tar.bz2
+osx-64/vigra-1.11.1-py38h1fc90aa_1030.tar.bz2
+osx-64/vigra-1.11.1-py39hdc3c630_1030.tar.bz2
+win-64/vigra-1.11.1-py310h19cbd51_1030.tar.bz2
+win-64/vigra-1.11.1-py37haa9f8d0_1030.tar.bz2
+win-64/vigra-1.11.1-py38hc8e63ce_1030.tar.bz2
+win-64/vigra-1.11.1-py39hf198278_1030.tar.bz2
+linux-64/vigra-1.11.1-py310hb5305c7_1030.tar.bz2
+linux-64/vigra-1.11.1-py37h90436ee_1030.tar.bz2
+linux-64/vigra-1.11.1-py37hd967b22_1030.tar.bz2
+linux-64/vigra-1.11.1-py38hadd2de3_1030.tar.bz2
+linux-64/vigra-1.11.1-py39h21e563c_1030.tar.bz2


### PR DESCRIPTION
Vigra is quite old and hasn't been updating cmake files for a while.

This makes migrations tricky.

I fixed openexr support in https://github.com/conda-forge/vigra-feedstock/pull/92

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata pacthes to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.

Checklist:

* [ ] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [ ] Added a description of the problem with the package in the PR description.
* [ ] Added links to any relevant issues/PRs in the PR description.
* [ ] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
