### PR TITLE
Remove new scikit-learn<1.0 for py310

### DIFF
--- a/broken/sklearn.txt
+++ b/broken/sklearn.txt
@@ -1,0 +1,6 @@
+linux-64/scikit-learn-0.24.2-py310hffb9edd_2.tar.bz2
+linux-aarch64/scikit-learn-0.24.2-py310h960e1e0_2.tar.bz2
+linux-ppc64le/scikit-learn-0.24.2-py310h1063a06_2.tar.bz2
+osx-64/scikit-learn-0.24.2-py310hddb2b46_2.tar.bz2
+osx-arm64/scikit-learn-0.24.2-py310hdf675a2_2.tar.bz2
+win-32/scikit-learn-0.24.2-py310h4dafddf_2.tar.bz2

--- a/broken/sklearn.txt
+++ b/broken/sklearn.txt
@@ -3,4 +3,4 @@ linux-aarch64/scikit-learn-0.24.2-py310h960e1e0_2.tar.bz2
 linux-ppc64le/scikit-learn-0.24.2-py310h1063a06_2.tar.bz2
 osx-64/scikit-learn-0.24.2-py310hddb2b46_2.tar.bz2
 osx-arm64/scikit-learn-0.24.2-py310hdf675a2_2.tar.bz2
-win-32/scikit-learn-0.24.2-py310h4dafddf_2.tar.bz2
+win-64/scikit-learn-0.24.2-py310h4dafddf_2.tar.bz2


### PR DESCRIPTION
Reference: <https://github.com/conda-forge/scikit-learn-feedstock/pull/182>

I added a legacy build of sklearn for py310. Turns out it was unwanted, and sklearn with py310 is unsupported for versions <1.0. Hence the request to mark as broken.

Files to remove are from 2 days ago [here](https://anaconda.org/conda-forge/scikit-learn/files).

Checklist:

* [X] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [X] Added a description of the problem with the package in the PR description.
* [X] Added links to any relevant issues/PRs in the PR description.
* [X] Pinged the team for the package for their input.

ping @conda-forge/scikit-learn 
<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
