### PR TITLE
mark current openssl 3.0.4 builds as broken on x86

### DIFF
--- a/broken/openssl.txt
+++ b/broken/openssl.txt
@@ -1,0 +1,6 @@
+linux-64/openssl-3.0.4-h166bdaf_0.tar.bz2
+linux-64/openssl-3.0.4-h166bdaf_1.tar.bz2
+osx-64/openssl-3.0.4-hfe4f2af_0.tar.bz2
+osx-64/openssl-3.0.4-hfe4f2af_1.tar.bz2
+win-64/openssl-3.0.4-h8ffe710_0.tar.bz2
+win-64/openssl-3.0.4-h8ffe710_1.tar.bz2


### PR DESCRIPTION
This is an optional-but-IMO-good-idea companion to https://github.com/conda-forge/openssl-feedstock/pull/100, due to the [potential](https://guidovranken.com/2022/06/27/notes-on-openssl-remote-memory-corruption/) to exploit 3.0.4.

Since this only affects AVX512, we don't need to do this on aarch64/ppc64le/arm64.

Filled by:
```
mamba repoquery search openssl=3.0.4 -p linux-64 --json | grep url | awk -F'conda-forge/' '{print $2}'  | awk -F'",' '{print $1}'
mamba repoquery search openssl=3.0.4 -p osx-64 --json | grep url | awk -F'conda-forge/' '{print $2}'  | awk -F'",' '{print $1}'
mamba repoquery search openssl=3.0.4 -p win-64 --json | grep url | awk -F'conda-forge/' '{print $2}'  | awk -F'",' '{print $1}'
```