### PR TITLE
Mark requests-2.28.0-pyhd8ed1ab_0 as broken

### DIFF
--- a/broken/requests.txt
+++ b/broken/requests.txt
@@ -1,0 +1,1 @@
+noarch/requests-2.28.0-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
`requests` has an optional runtime dependency on `chardet <5`, but this wasn't encoded in the feedstock for 2.28.0-0. This has been fixed in build 1.  See https://github.com/conda-forge/requests-feedstock/pull/54 and https://github.com/conda-forge/requests-feedstock/pull/54#issuecomment-1167251225. 

Ping @conda-forge/requests

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.


