### PR TITLE
Add clr_loader with missing files to broken packages

### DIFF
--- a/not_broken/clr_loader.txt
+++ b/not_broken/clr_loader.txt
@@ -1,0 +1,1 @@
+noarch/clr_loader-0.1.7-pyhd8ed1ab_3.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

In transition to `noarch` (https://github.com/conda-forge/clr_loader-feedstock/pull/3) something went wrong with the files to include (https://github.com/conda-forge/clr_loader-feedstock/issues/4). Im working on a fix (https://github.com/conda-forge/clr_loader-feedstock/pull/5) to include the files again and test for existence of these files (my bad).