### PR TITLE
add broken attrs 22.1.0 build 0

### DIFF
--- a/broken/attrs-22.1.0_0.txt
+++ b/broken/attrs-22.1.0_0.txt
@@ -1,0 +1,1 @@
+noarch/attrs-22.1.0-pyh71513ae_0.tar.bz2


### PR DESCRIPTION
Broken because [attrs dropped Python 2.7 support in 22.1.0](https://github.com/python-attrs/attrs/releases/tag/22.1.0), but this didn't get changed in the conda-forge recipe.

PR to fix the recipe: https://github.com/conda-forge/attrs-feedstock/pull/27

ping @conda-forge/attrs 

---

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
