### PR TITLE
mark cmake-built libprotobuf's broken on unix

### DIFF
--- a/broken/libprotobuf.txt
+++ b/broken/libprotobuf.txt
@@ -1,2 +1,10 @@
+linux-64/libprotobuf-3.20.1-h6239696_2.tar.bz2
+linux-64/libprotobuf-3.21.5-h6239696_1.tar.bz2
+linux-aarch64/libprotobuf-3.20.1-h7866ba4_2.tar.bz2
+linux-aarch64/libprotobuf-3.21.5-h7866ba4_1.tar.bz2
+linux-ppc64le/libprotobuf-3.20.1-ha72a2fa_2.tar.bz2
+linux-ppc64le/libprotobuf-3.21.5-ha72a2fa_1.tar.bz2
 osx-64/libprotobuf-3.20.1-hbc0c0cd_2.tar.bz2
 osx-64/libprotobuf-3.21.5-hbc0c0cd_1.tar.bz2
+osx-arm64/libprotobuf-3.20.1-hb5ab8b9_2.tar.bz2
+osx-arm64/libprotobuf-3.21.5-hb5ab8b9_1.tar.bz2

--- a/broken/libprotobuf.txt
+++ b/broken/libprotobuf.txt
@@ -1,0 +1,2 @@
+osx-64/libprotobuf-3.20.1-hbc0c0cd_2.tar.bz2
+osx-64/libprotobuf-3.21.5-hbc0c0cd_1.tar.bz2


### PR DESCRIPTION
There's some fall-out from building libprotobuf via cmake, see post-merge comments in https://github.com/conda-forge/libprotobuf-feedstock/pull/128.

It's bizarre to me because the SO-numbers match (see this [comment](https://github.com/conda-forge/libprotobuf-feedstock/pull/128#issuecomment-1238947823)), but mark it broken for now to not further break people.

~Original reporter (@peastman) mentioned specifically that:~
> ~This only happens on x86, not ARM.~

Queries used:
```
mamba repoquery search libprotobuf=3.20.1=*_2 -p osx-64 --json | grep url | awk -F'conda-forge/' '{print $2}'  | awk -F'",' '{print $1}
mamba repoquery search libprotobuf=3.21.5=*_1 -p osx-64 --json | grep url | awk -F'conda-forge/' '{print $2}'  | awk -F'",' '{print $1}
```
and so on for the other platforms