### PR TITLE
Mark as broken assimp windows package with changed name

### DIFF
--- a/broken/assimp.txt
+++ b/broken/assimp.txt
@@ -1,0 +1,1 @@
+win-64/assimp-5.2.4-h4dcb625_1.tar.bz2


### PR DESCRIPTION
As discussed in https://github.com/conda-forge/assimp-feedstock/issues/45#issuecomment-1242976661, there was an uninteded ABI breakage due to a spurious change of library name in the updated (due to rerendering) from VS2017 to VS2019 .

This has been solved in https://github.com/conda-forge/assimp-feedstock/pull/47, but there is still around the build with wrong names, this PR marks it as broken.

fyi @conda-forge/assimp 


Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
