### PR TITLE
Mark OpenFF Evaluator RC package pushed to wrong label

### DIFF
--- a/broken/evaluator.txt
+++ b/broken/evaluator.txt
@@ -1,0 +1,1 @@
+noarch/openff-evaluator-0.4.0rc4-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
I accidentally did pushed to upstream version of a feedstock instead of my fork, which to my surprise caused an RC build to be published without the appropriate labelling. The rest of the process went fine (https://github.com/conda-forge/openff-evaluator-feedstock/pull/20) and there is an RC build online with the RC label I intended. I am afraid the solver may pull down this RC build, which includes many API breaks and new dependency constraints, instead of a full release.

I asked in the gitter how to go about getting this fixed, since I cannot do it myself. It was suggested that I ask to mark it as broken instead of patching the repodata as repodata patches do not update labels.

Thanks!