### PR TITLE
mark dask-kubernetes as broken

### DIFF
--- a/broken/dask-kubernetes.txt
+++ b/broken/dask-kubernetes.txt
@@ -1,0 +1,1 @@
+noarch/dask-kubernetes-2022.9.0-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
Automerge has been publishing bad packages for a while but let's remove at least this last one to be sure only 1 build number is correct.