### PR TITLE
Marks qgrid as broken due to failing post-link script

### DIFF
--- a/broken/qgrid-broken.txt
+++ b/broken/qgrid-broken.txt
@@ -1,0 +1,1 @@
+noarch/qgrid-1.3.1-pyhd8ed1ab_3.tar.bz2


### PR DESCRIPTION
When installing qgrid as part of an existing environment, it will solve to the _3 version. This version is broken with changes to upstream packages (jupyter-nbclassic). 

See:

https://github.com/conda-forge/qgrid-feedstock/pull/37

https://github.com/conda-forge/qgrid-feedstock/issues/35
https://github.com/quantopian/qgrid/issues/378
https://github.com/tardis-sn/tardis/issues/2137

```ERROR conda.core.link:_execute(701): An error occurred while installing package 'conda-forge::qgrid-1.3.1-pyhd8ed1ab_3'.
Rolling back transaction: done

LinkError: post-link script failed for package conda-forge::qgrid-1.3.1-pyhd8ed1ab_3
location of failed script: /home/afullard/.conda/envs/tardis2/bin/.qgrid-post-link.sh
==> script messages <==
<None>
==> script output <==
stdout: 
stderr: 
return code: 1
```

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

ping @conda-forge/qgrid-feedstock
