### PR TITLE
Remove pytango 9.4.0rc1 from main channel

### DIFF
--- a/broken/pytango.txt
+++ b/broken/pytango.txt
@@ -1,0 +1,12 @@
+win-64/pytango-9.4.0rc1-py311h44fd347_0.tar.bz2
+win-64/pytango-9.4.0rc1-py310hdd9df50_0.tar.bz2
+win-64/pytango-9.4.0rc1-py39h191c697_0.tar.bz2
+win-64/pytango-9.4.0rc1-py38h07a3158_0.tar.bz2
+osx-64/pytango-9.4.0rc1-py311hd5f11b7_0.tar.bz2
+osx-64/pytango-9.4.0rc1-py310ha189008_0.tar.bz2
+osx-64/pytango-9.4.0rc1-py39hcf773c3_0.tar.bz2
+osx-64/pytango-9.4.0rc1-py38hb3574e1_0.tar.bz2
+linux-64/pytango-9.4.0rc1-py311h1085b10_0.tar.bz2
+linux-64/pytango-9.4.0rc1-py310h150de76_0.tar.bz2
+linux-64/pytango-9.4.0rc1-py39hf983217_0.tar.bz2
+linux-64/pytango-9.4.0rc1-py38hb9d02da_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.

Checklist:

* [X] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [X] Added a description of the problem with the package in the PR description.
* [X] Added links to any relevant issues/PRs in the PR description.
* [X] Pinged the team for the package for their input.

I wanted to release a `rc` version of pytango and pushed to a `rc` branch but I did a mistake when adding the `conda_build_config.yaml` file: https://github.com/conda-forge/pytango-feedstock/commit/03f8f7f34de6f59809cd638963aeeb838d89f750

I used `channels_target` instead of `channel_targets` :-( The 9.4.0rc1 version of pytango ended in the main channel
and I'd like to remove it. Or is it possible to move those files to the `pytango_rc` channel?

Fixed in https://github.com/conda-forge/pytango-feedstock/pull/13

ping @conda-forge/pytango
