### PR TITLE
Mark googleapis-common-protos 1.57.0 build 1 as broken

### DIFF
--- a/broken/googleapis-common-protos.txt
+++ b/broken/googleapis-common-protos.txt
@@ -1,0 +1,2 @@
+noarch/googleapis-common-protos-1.57.0-pyhd8ed1ab_1.conda
+noarch/googleapis-common-protos-grpc-1.57.0-pyhd8ed1ab_1.conda


### PR DESCRIPTION
This build vendored files from other packages installed alongside the main package.

See https://github.com/conda-forge/googleapis-common-protos-feedstock/issues/50 for more details.

The broken build was: https://github.com/conda-forge/googleapis-common-protos-feedstock/pull/49

This was fixed in build 2: https://github.com/conda-forge/googleapis-common-protos-feedstock/pull/51

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
