### PR TITLE
Mark conda=22.11.0 as broken

### DIFF
--- a/broken/conda-22.11.0.txt
+++ b/broken/conda-22.11.0.txt
@@ -1,0 +1,9 @@
+osx-64/conda-22.11.0-py311h6eed73b_0.conda
+osx-arm64/conda-22.11.0-py311h267d04e_0.conda
+linux-64/conda-22.11.0-py311h38be061_0.conda
+linux-aarch64/conda-22.11.0-py311hec3470c_0.conda
+linux-ppc64le/conda-22.11.0-py311h1af927a_0.conda
+win-64/conda-22.11.0-py38haa244fe_0.conda
+win-64/conda-22.11.0-py39hcbf5309_0.conda
+win-64/conda-22.11.0-py310h5588dad_0.conda
+win-64/conda-22.11.0-py311h1ea47a8_0.conda


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

Whilst trying the build/upload remaining builds of `conda=22.11.0` itself, we noticed `conda-mambabuild`+`conda=22.11.0` wasn't able to solve the `build` environment for Python 3.11 builds of `conda`. (In PR https://github.com/conda-forge/conda-feedstock/pull/190 )
Let's mark this version as `broken` until we figure out the culprit.

ping @conda-forge/conda