### PR TITLE
mark pytest-jupyter-* 0.5.3*_1, 0.6.0*_0 broken

### DIFF
--- a/broken/pytest-jupyter.txt
+++ b/broken/pytest-jupyter.txt
@@ -1,0 +1,12 @@
+linux-64/pytest-jupyter-0.6.0-py311ha770c72_0.conda
+linux-64/pytest-jupyter-client-0.6.0-py311ha770c72_0.conda
+linux-64/pytest-jupyter-server-0.6.0-py311ha770c72_0.conda
+noarch/pytest-jupyter-0.5.3-pyhd8ed1ab_1.conda
+noarch/pytest-jupyter-client-0.5.3-pyhd8ed1ab_1.conda 
+noarch/pytest-jupyter-server-0.5.3-pyhd8ed1ab_1.conda 
+osx-64/pytest-jupyter-0.6.0-py311h694c41f_0.conda
+osx-64/pytest-jupyter-client-0.6.0-py311h694c41f_0.conda
+osx-64/pytest-jupyter-server-0.6.0-py311h694c41f_0.conda
+win-64/pytest-jupyter-0.6.0-py311h57928b3_0.conda
+win-64/pytest-jupyter-client-0.6.0-py311h57928b3_0.conda
+win-64/pytest-jupyter-server-0.6.0-py311h57928b3_0.conda


### PR DESCRIPTION
Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.


Description:


When doing an `outputs` build of `0.5.3`, I missed `noarch: python` in the subpackages. 

- https://github.com/conda-forge/pytest-jupyter-feedstock/pull/3


This yielded a bunch of super broken builds that also vendored `pytest` and much of the `jupyter` stack.

- https://github.com/conda-forge/pytest-jupyter-feedstock/issues/4

A successive build of `0.6.0` somehow made the problem worse.

A fix has been deployed:

- https://github.com/conda-forge/pytest-jupyter-feedstock/pull/3

@conda-forge/jupyter_server _mea culpa_ :crying_cat_face: 