### PR TITLE
Add broken networkx build

### DIFF
--- a/broken/networkx.txt
+++ b/broken/networkx.txt
@@ -1,0 +1,1 @@
+noarch/networkx-2.7.1-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. Note that if you are asking for a package to
be marked as broken, please make sure to explain why in the PR text below.

Cheers and thank you for contributing to conda-forge!
-->

Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.

Checklist:

* [x] Make sure your package is in the right spot (`broken/*` for adding the
  `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
  for token resets)
* [x] Added a description of the problem with the package in the PR description.
* [x] Added links to any relevant issues/PRs in the PR description.
* [x] Pinged the team for the package for their input.

Issue (taken from the linked issue below)

> In an empty conda envrionment I run conda install python=3.7 networkx.
I end up getting networkx version 2.7.1.
When I go to the github tag for networkx version 2.7.1 I see that there is a requirement for python >=3.8: https://github.com/networkx/networkx/blob/networkx-2.7.1/setup.py#L195
Looking at commits on networkx-feedstock I see the first commit for 2.7.1 [here](https://github.com/conda-forge/networkx-feedstock/commit/b871075db44054acabcaba96aa046e99d7c39733) and then a correction for the version [here](https://github.com/conda-forge/networkx-feedstock/commit/89d2c0221d2e709c78d0cffc18d50859f1b4b8ff). The correction fixes the dependency issue.
I am getting the first commit, build 0 of networkx 2.7.1. This is unexpected behavior. Is this avoidable on my end or is this something that can be fixed on your end?


Relevant issues: https://github.com/conda-forge/networkx-feedstock/issues/44
ping @conda-forge/networkx-feedstock