### PR TITLE
Reset token for hdbpp-es-feedstock

### DIFF
--- a/token_reset/hdbpp-es.txt
+++ b/token_reset/hdbpp-es.txt
@@ -1,0 +1,2 @@
+hdbpp-es
+hdbpp-es-dbg

--- a/token_reset/hdbpp-es.txt
+++ b/token_reset/hdbpp-es.txt
@@ -1,2 +1,1 @@
 hdbpp-es
-hdbpp-es-dbg


### PR DESCRIPTION
The new build of hdbpp-es failed to upload. I guess this is linked to https://github.com/conda-forge/status/issues/137

The feedstock has 2 outputs: `hdbpp-es` and `hdbpp-es-dbg`.

I put both in the same `hdbpp-es.txt` file but I'm not sure this is correct or if I should create two txt files.
