### PR TITLE
reset token for conda-forge-pinning

### DIFF
--- a/token_reset/conda-forge-pinning.txt
+++ b/token_reset/conda-forge-pinning.txt
@@ -1,0 +1,1 @@
+conda-forge-pinning


### PR DESCRIPTION
Builds on the feedstock are failing, which is why migrations aren't opened/closed correctly.

This one should be pretty urgent. CC @beckermr @jakirkham 