### PR TITLE
remove sphinx-autodoc-typehints

### DIFF
--- a/broken/sphinx-autodoc-typehints.txt
+++ b/broken/sphinx-autodoc-typehints.txt
@@ -1,0 +1,1 @@
+noarch/sphinx-autodoc-typehints-1.23.4-pyhd8ed1ab_0.conda


### PR DESCRIPTION
This version was yanked from PyPI. Closes https://github.com/conda-forge/sphinx-autodoc-typehints-feedstock/issues/39