### PR TITLE
Mark jupyter_server_ydoc=0.6.2 as broken

### DIFF
--- a/broken/jupyter_server_ydoc.txt
+++ b/broken/jupyter_server_ydoc.txt
@@ -1,0 +1,1 @@
+noarch/jupyter_server_ydoc-0.6.2-pyhd8ed1ab_0.conda


### PR DESCRIPTION
`jupyter_server_ydoc` v0.6.2 pins `jupyter_ydoc >=0.3.0` and should have been released as v0.7.0 in order not to break `jupyterlab` v3.6.0.
`jupyter_server_ydoc` v0.6.2 has been yanked [on PyPI](https://pypi.org/project/jupyter-server-ydoc/0.6.2).

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

  ping @conda-forge/jupyter_server, @hbcarlos, @fcollonval
