### PR TITLE
remove bad xbitinfo versions

### DIFF
--- a/broken/xbitinfo.txt
+++ b/broken/xbitinfo.txt
@@ -1,0 +1,3 @@
+linux-64/xbitinfo-python-0.0.4.dev1-py311ha770c72_0.conda
+noarch/xbitinfo-0.0.4.dev1-hd8ed1ab_0.conda
+noarch/xbitinfo-0.0.4.dev0-pyhd8ed1ab_0.conda


### PR DESCRIPTION
These dev releases were published on main, have the wrong Python dependency, and were superseded but the correct version that implements both Python and Julia packages. Marking them as broken is the easiest thing here b/c it is not worth patching them.