### PR TITLE
r-cli v3 noarchs broken

### DIFF
--- a/broken/r-cli.txt
+++ b/broken/r-cli.txt
@@ -1,0 +1,4 @@
+noarch/r-cli-3.0.0-r40hc72bb7e_0.tar.bz2
+noarch/r-cli-3.0.0-r41hc72bb7e_0.tar.bz2
+noarch/r-cli-3.0.1-r40hc72bb7e_0.tar.bz2
+noarch/r-cli-3.0.1-r41hc72bb7e_0.tar.bz2


### PR DESCRIPTION
We identified `r-cli-feedstock` was generating non-functional builds due to upstream no longer being `noarch` compatible. The recipe was corrected, but the broken builds are still on `main`. This marks them as broken.

Related Issues:
- https://github.com/conda-forge/r-cli-feedstock/issues/20
- https://github.com/conda-forge/r-tidyverse-feedstock/issues/13

I am on the maintainer team, but for good measure we can also ping @conda-forge/r-cli 

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.
