### PR TITLE
reset token for clang-compiler-activation

### DIFF
--- a/token_reset/clang-compiler-activation.txt
+++ b/token_reset/clang-compiler-activation.txt
@@ -1,0 +1,1 @@
+clang-compiler-activation

--- a/token_reset/example.txt
+++ b/token_reset/example.txt
@@ -1,1 +1,1 @@
-pyrsm
+cf-autotick-bot-test-package


### PR DESCRIPTION
Also restore the example as a drive-by fix.

Fixes https://github.com/conda-forge/clang-compiler-activation-feedstock/issues/98