### PR TITLE
mark cctools build number 12 broken on osx

### DIFF
--- a/broken/cctools.txt
+++ b/broken/cctools.txt
@@ -1,0 +1,2 @@
+osx-64/cctools-973.0.1-hd9ad811_12.conda
+osx-arm64/cctools-973.0.1-hd1ac623_12.conda

--- a/broken/cctools_osx-64.txt
+++ b/broken/cctools_osx-64.txt
@@ -1,0 +1,2 @@
+osx-64/cctools_osx-64-973.0.1-h48a5a9d_12.conda
+osx-arm64/cctools_osx-64-973.0.1-h1497617_12.conda

--- a/broken/cctools_osx-arm64.txt
+++ b/broken/cctools_osx-arm64.txt
@@ -1,0 +1,2 @@
+osx-64/cctools_osx-arm64-973.0.1-hd9287c6_12.conda
+osx-arm64/cctools_osx-arm64-973.0.1-hcdc440c_12.conda

--- a/broken/ld64.txt
+++ b/broken/ld64.txt
@@ -1,0 +1,2 @@
+osx-64/ld64-609-ha91a046_12.conda
+osx-arm64/ld64-609-h89fa09d_12.conda

--- a/broken/ld64_osx-64.txt
+++ b/broken/ld64_osx-64.txt
@@ -1,0 +1,2 @@
+osx-64/ld64_osx-64-609-h8ce0179_12.conda
+osx-arm64/ld64_osx-64-609-h559a9e4_12.conda

--- a/broken/ld64_osx-arm64.txt
+++ b/broken/ld64_osx-arm64.txt
@@ -1,0 +1,2 @@
+osx-64/ld64_osx-arm64-609-ha71a1fd_12.conda
+osx-arm64/ld64_osx-arm64-609-h74cdc5f_12.conda


### PR DESCRIPTION
Since llvm 15 started depending on libxml2 (which itself depends on a few libs), conda twists itself into a knot when trying to rebuild one of those dependencies. Even though this feedstock [pins](https://github.com/conda-forge/cctools-and-ld64-feedstock/blob/main/recipe/meta.yaml#L70) `llvm` to an exact version, which in turn [exports](https://github.com/conda-forge/llvmdev-feedstock/blob/main/recipe/meta.yaml#L105) `libllvm<same_major>`, the actual clang-implementation doesn't [pin](https://github.com/conda-forge/clang-compiler-activation-feedstock/blob/main/recipe/meta.yaml#L39-L40) cctools.

After fixing this inhttps://github.com/conda-forge/cctools-and-ld64-feedstock/pull/59, mark the old builds as broken so the resolver can't get caught in this trap (=package with too loose constraints) anymore.