### PR TITLE
Mark xeus-zmq 1.0.2 build 0 as broken

### DIFF
--- a/broken/xeus-zmq.txt
+++ b/broken/xeus-zmq.txt
@@ -1,0 +1,7 @@
+linux-64/xeus-zmq-1.0.2-h0541b36_0.conda
+linux-aarch64/xeus-zmq-1.0.2-hb74a78a_0.conda
+linux-ppc64le/xeus-zmq-1.0.2-h1711066_0.conda
+osx-64/xeus-zmq-1.0.2-ha27c2bb_0.conda
+osx-arm64/xeus-zmq-1.0.2-h54398fd_0.conda
+win-64/xeus-zmq-1.0.2-h449d27f_0.conda
+


### PR DESCRIPTION
As per https://github.com/conda-forge/xeus-zmq-feedstock/issues/11.

Fixes https://github.com/conda-forge/xeus-zmq-feedstock/issues/11/.