### PR TITLE
Specifying broken files for openmmtools pkg build

### DIFF
--- a/broken/openmmtools0215_build_0.txt
+++ b/broken/openmmtools0215_build_0.txt
@@ -1,0 +1,1 @@
+noarch/openmmtools-0.21.5-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
The `openmmtools` 0.21.5 package in [noarch/openmmtools-0.21.5-pyhd8ed1ab_0.tar.bz2](https://anaconda.org/conda-forge/openmmtools/0.21.5/download/noarch/openmmtools-0.21.5-pyhd8ed1ab_0.tar.bz2) is broken since it doesn't work with the upstream dependencies, we want to avoid this build of the package to be pulled by users. The `*_1` build should be used instead.

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
