### PR TITLE
Mark sardana 3.4.0 build 0 as broken

### DIFF
--- a/broken/sardana.txt
+++ b/broken/sardana.txt
@@ -1,0 +1,4 @@
+noarch/sardana-3.4.0-pyhd8ed1ab_0.conda
+noarch/sardana-config-3.4.0-pyhd8ed1ab_0.conda
+noarch/sardana-server-3.4.0-pyhd8ed1ab_0.conda
+noarch/sardana-client-3.4.0-pyhd8ed1ab_0.conda


### PR DESCRIPTION


<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [X] I want to mark a package as broken (or not broken):
  * [X] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [X] Added a description of the problem with the package in the PR description.
  * [X] Pinged the team for the package for their input.


ping @conda-forge/sardana

The sardana package was split in several subpackages in version [3.4.0](https://github.com/conda-forge/sardana-feedstock/pull/19) but the names used (`sardana-server` / `sardana-client`) were considered confusing and we changed them in build 1 to `sardana-core` / `sardana-qt`: https://github.com/conda-forge/sardana-feedstock/pull/20

To avoid confusion for the users, we'd like the `sardana-server` / `sardana-client` packages to be marked as broken (meaning all subpackages from build 0).