### PR TITLE
Remove broken kokkos-kernels build #0.

### DIFF
--- a/broken/kokkos-kernels.txt
+++ b/broken/kokkos-kernels.txt
@@ -1,0 +1,2 @@
+linux-64/kokkos-kernels-3.7.01-hf52228f_0.conda
+osx-64/kokkos-kernels-3.7.01-h5aaa8d0_0.conda


### PR DESCRIPTION
Kokkos-kernels v3.7.01 should depend on Kokkos v3.7.01, but it depends on v4.0.0. 

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

