### PR TITLE
archive cpp-opentelemetry-api

### DIFF
--- a/archive/cpp-opentelemetry-api.txt
+++ b/archive/cpp-opentelemetry-api.txt
@@ -1,0 +1,1 @@
+cpp-opentelemetry-api


### PR DESCRIPTION
The [feedstock](https://github.com/conda-forge/cpp-opentelemetry-api-feedstock) was unified with another in https://github.com/conda-forge/cpp-opentelemetry-sdk-feedstock/pull/46 and is now obsolete