### PR TITLE
Remove broken kokkos cuda packages

### DIFF
--- a/broken/kokkos3-cuda.txt
+++ b/broken/kokkos3-cuda.txt
@@ -1,0 +1,8 @@
+linux-64/kokkos-3.7.02-h1e7fabd_0.conda
+linux-64/kokkos-3.7.02-h22b3db6_1.conda
+linux-64/kokkos-3.7.02-h66b1f04_0.conda
+linux-64/kokkos-3.7.02-h69fb06d_1.conda
+linux-aarch64/kokkos-3.7.02-h5405a99_0.conda
+linux-aarch64/kokkos-3.7.02-h69b1e34_1.conda
+linux-ppc64le/kokkos-3.7.02-hc023538_1.conda
+linux-ppc64le/kokkos-3.7.02-hd810a49_0.conda


### PR DESCRIPTION
I published CUDA builds for Kokkos 3 targeting arch 3.5 + PTX, but Kokkos does not support CUDA binaries with PTX until Kokkos 4. Conda requires building conda packages for all CUDA compatible major architectures or building for the lowest and including PTX for forward compatability because Conda does not track CUDA archs, however, Kokkos only supports targeting one CUDA arch at build time, so it must be built with PTX.

The effect of leaving these broken packages is that programs that link against them but are running on hardware later than 3.5 may stall/hang OR the runtime will raise an error about the library being compiled for the wrong architecture.

Discussion of this and other Kokkos with CUDA packaging issues are here: 
https://github.com/conda-forge/kokkos-feedstock/issues/21

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
