### PR TITLE
Yank noarch/joblib-1.3.0 b0

### DIFF
--- a/broken/joblib.txt
+++ b/broken/joblib.txt
@@ -1,0 +1,1 @@
+noarch/joblib-1.3.0-pyhd8ed1ab_0.conda


### PR DESCRIPTION
Version 1.3.0 no longer supports Python 3.6:

https://github.com/joblib/joblib/blob/1.3.0/pyproject.toml#L28

This has been fixed in https://github.com/conda-forge/joblib-feedstock/pull/38 already, but the broken package is still available which causes problems for downstream users using Python 3.6.
