### PR TITLE
Mark spacy-transformers 1.3.0 as broken

### DIFF
--- a/broken/spacy-transformers-1.3.0.txt
+++ b/broken/spacy-transformers-1.3.0.txt
@@ -1,0 +1,8 @@
+osx-64/spacy-transformers-1.3.0-py310h9209b79_0.conda
+osx-64/spacy-transformers-1.3.0-py38hba43d4d_0.conda
+osx-64/spacy-transformers-1.3.0-py39h204a2a1_0.conda
+osx-64/spacy-transformers-1.3.0-py311hd5c4f45_0.conda
+linux-64/spacy-transformers-1.3.0-py310hfb6f7a9_0.conda
+linux-64/spacy-transformers-1.3.0-py38h905acbe_0.conda
+linux-64/spacy-transformers-1.3.0-py311h92ebd52_0.conda
+linux-64/spacy-transformers-1.3.0-py39hf86192f_0.conda


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

The package itself is not technically 100% broken, but we have found a number of incompatibilities in use with `transformers` v4.31 and the only significant difference to the previous release (`spacy-transformers` v1.2.5) is the extended `transformers` requirement.

The corresponding release has been yanked on PyPI and the conda-forge package was only published yesterday, so there are few downloads/users.