### PR TITLE
Remove `CalVer` packages for `ShakeNBreak`

### DIFF
--- a/broken/shakenbreak.txt
+++ b/broken/shakenbreak.txt
@@ -1,0 +1,5 @@
+noarch/shakenbreak-23.6.23-pyhd8ed1ab_0.tar.bz2
+noarch/shakenbreak-23.4.27-pyhd8ed1ab_2.tar.bz2
+noarch/shakenbreak-23.4.27-pyhd8ed1ab_0.tar.bz2
+noarch/shakenbreak-23.1.7-pyhd8ed1ab_0.tar.bz2
+noarch/shakenbreak-22.12.2-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock

Cheers and thank you for contributing to conda-forge!
-->

Hi! 
We are kindly requesting removal of old `CalVer` versions of `ShakeNBreak` on `conda-forge` (https://github.com/conda-forge/shakenbreak-feedstock). These packages were unfortunately published with calendar versioning, e.g. `2023.6.23`. This has been corrected with the recent switch to `SemVer`, but because of `SemVer` version ordering, `2023.6.23` still shows up as the latest and default version for the package which is problematic for installing users.

Checked, and no dependents in `regro/libcfgraph` were found. To our knowledge, no other packages depend on these versions of `ShakeNBreak`, our latest version is compatible with a wider range of python versions (`3.8` - `3.11`) with looser dependency requirements, and worst case scenario if one of these versions is required by someone else then they're available on `PyPI` (but yanked so that they're ignored unless explicitly requested). 

Sorry about the hassle, and thanks for your time!

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
