### PR TITLE
Only glob files with txt extension

### DIFF
--- a/archive_feedstock.py
+++ b/archive_feedstock.py
@@ -8,7 +8,7 @@ import subprocess
 def get_task_files(task):
     exf = os.path.join(task, "example.txt")
     return [
-        f for f in glob.glob(os.path.join(task, "*"))
+        f for f in glob.glob(os.path.join(task, "*.txt"))
         if f != exf
     ]
 

--- a/mark_broken.py
+++ b/mark_broken.py
@@ -21,13 +21,13 @@ def split_pkg(pkg):
 
 def get_broken_files():
     return (
-        [f for f in glob("broken/*") if f != "broken/example.txt"]
-        + [f for f in glob("pkgs/*") if f != "pkgs/example.txt"]
+        [f for f in glob("broken/*.txt") if f != "broken/example.txt"]
+        + [f for f in glob("pkgs/*.txt") if f != "pkgs/example.txt"]
     )
 
 
 def get_not_broken_files():
-    return [f for f in glob("not_broken/*") if f != "not_broken/example.txt"]
+    return [f for f in glob("not_broken/*.txt") if f != "not_broken/example.txt"]
 
 
 def check_packages():

--- a/token_reset.py
+++ b/token_reset.py
@@ -51,7 +51,7 @@ def delete_feedstock_token(feedstock_name):
 def get_token_reset_files():
     return (
         [
-            f for f in glob.glob("token_reset/*")
+            f for f in glob.glob("token_reset/*.txt")
             if f != "token_reset/example.txt"
         ]
     )


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock

Cheers and thank you for contributing to conda-forge!
-->

## Description

Currently, the README tells contributors to add files with a .txt extension, and the [fast finish](https://github.com/conda-forge/admin-requests/blob/f688e516044556305fa160ba632017ac383aafee/.github/workflows/main.yml#L32-L36) code in the CI also looks for txt files. However, the python scripts in the root folder will happily glob any file regardless of extension. This can lead to [careless users submitting PR's](https://github.com/conda-forge/admin-requests/pull/794) that [look okay in the PR's CI run](https://github.com/conda-forge/admin-requests/actions/runs/5864699118/job/15901307635#step:4:1) but then [don't do anything when merged to main](https://github.com/conda-forge/admin-requests/actions/runs/5865447965/job/15902394960#step:5:44).

This change makes sure that the Python scripts only pick up txt files, thus making tasks picked up by the `pr` and `main` workflows consistent.