### PR TITLE
Req to remove rc build from main iris channel.

### DIFF
--- a/broken/iris_main_remove_v3x0x0rc0.txt
+++ b/broken/iris_main_remove_v3x0x0rc0.txt
@@ -1,0 +1,1 @@
+noarch/iris-3.7.0rc0-pyha770c72_0.conda


### PR DESCRIPTION
The problem was created by a malformed push to the iris-feedstock/release-candidate branch.
This has mistakenly created an RC version package in the iris "main"  channel.

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
