### PR TITLE
Mark initial build of libprotobuf_python_headers as broken

### DIFF
--- a/broken/libprotobuf_python_headers.txt
+++ b/broken/libprotobuf_python_headers.txt
@@ -1,0 +1,6 @@
+linux-ppc64le/libprotobuf-python-headers-4.23.4-ha3edaa6_3.conda
+linux-aarch64/libprotobuf-python-headers-4.23.4-h8af1aa0_3.conda
+osx-arm64/libprotobuf-python-headers-4.23.4-hce30654_3.conda
+linux-64/libprotobuf-python-headers-4.23.4-ha770c72_3.conda
+osx-64/libprotobuf-python-headers-4.23.4-h694c41f_3.conda
+win-64/libprotobuf-python-headers-4.23.4-h57928b3_3.conda


### PR DESCRIPTION
I created this new @conda-forge/libprotobuf output and immediately after merge, I realised that a `run_constraint` is missing. The packages have not yet been used anywhere and thus I went with the simple approach of marking them as broken. Fix for the underlying problem is here: https://github.com/conda-forge/libprotobuf-feedstock/pull/177

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
