### PR TITLE
mark latest conda-smithy as broken

### DIFF
--- a/broken/conda-smithy.txt
+++ b/broken/conda-smithy.txt
@@ -1,0 +1,1 @@
+noarch/conda-smithy-3.25.0-pyhd8ed1ab_0.conda


### PR DESCRIPTION
This release has an issue with the swap_file on azure and that was fixed in https://github.com/conda-forge/conda-smithy/pull/1759

Previous releases and the next one should be OK.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
