### PR TITLE
Mark soupsieve 2.5_0 as broken

### DIFF
--- a/broken/soupsieve.txt
+++ b/broken/soupsieve.txt
@@ -1,0 +1,1 @@
+noarch/soupsieve-2.5-pyhd8ed1ab_0.conda


### PR DESCRIPTION
Mark soupsieve 2.5 build 0 as broken since it doesn't work on Python 3.6 environments (Build 1 fix this by adding `python >=3.8` to the recipe).

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.
