### PR TITLE
Remove configspace-0.7.2

### DIFF
--- a/broken/configspace.txt
+++ b/broken/configspace.txt
@@ -1,0 +1,12 @@
+win-64/configspace-0.7.2-py39hbaa61f9_0.conda
+win-64/configspace-0.7.2-py311h59ca53f_0.conda
+osx-64/configspace-0.7.2-py38hd2faf92_0.conda
+win-64/configspace-0.7.2-py38h634f036_0.conda
+win-64/configspace-0.7.2-py310h9b08ddd_0.conda
+osx-64/configspace-0.7.2-py39h57e1da4_0.conda
+osx-64/configspace-0.7.2-py311h4a70a88_0.conda
+osx-64/configspace-0.7.2-py310hc1335a1_0.conda
+linux-64/configspace-0.7.2-py39h0f8d45d_0.conda
+linux-64/configspace-0.7.2-py311h1f0f07a_0.conda
+linux-64/configspace-0.7.2-py310h278f3c1_0.conda
+linux-64/configspace-0.7.2-py38h31356c5_0.conda


### PR DESCRIPTION
ConfigSpace 0.7.2 is broken and has been removed by the authors from pypi (see https://github.com/automl/ConfigSpace/issues/336 or https://github.com/automl/ConfigSpace/issues/338).

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

ping @conda-forge/configspace 

