### PR TITLE
archive boost-cpp feedstock

### DIFF
--- a/archive/boost-cpp.txt
+++ b/archive/boost-cpp.txt
@@ -1,0 +1,1 @@
+boost-cpp

--- a/archive/boost-cpp.txt
+++ b/archive/boost-cpp.txt
@@ -1,1 +1,0 @@
-boost-cpp

--- a/requests/boost-archive.yml
+++ b/requests/boost-archive.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - boost-cpp


### PR DESCRIPTION
After https://github.com/conda-forge/boost-feedstock/pull/164, the [boost-cpp](https://github.com/conda-forge/boost-cpp-feedstock/) feedstock is now obsolete. I've closed issues and PRs as appropriate, and moved unresolved issues to the unified feedstock.

I guess the only point would be to keep the possibility to rebuild boost-cpp 1.78 if necessary (though that should hopefully soon be obsolete too by migrating to 1.82), otherwise I think we're good to go with archiving that feedstock