### PR TITLE
Bump to Python 3.9

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - anaconda-client
-  - python=3.8
+  - python=3.9
   - requests
   - conda-smithy
   - pygithub


### PR DESCRIPTION
`conda-forge-repodata-patches` uses `typing.Annotated`, which needs Python 3.9. This has been failing for the last 3 months 😬 