### PR TITLE
Bump to Python 3.10

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - anaconda-client
-  - python=3.9
+  - python=3.10
   - requests
   - conda-smithy
   - pygithub


### PR DESCRIPTION
Follow up for #860. Type `|` unions require Python 3.10.