### PR TITLE
Mark linux-64 conda-index 0.3.0 broken

### DIFF
--- a/broken/conda-index.txt
+++ b/broken/conda-index.txt
@@ -1,0 +1,1 @@
+linux-64/conda-index-0.3.0-py310ha770c72_0.conda


### PR DESCRIPTION
This package was unintentionally published from a branch build and should not be used.

See: https://github.com/conda-forge/conda-index-feedstock/pull/1#issuecomment-1791113088

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Make sure your package is in the right spot (`broken/*` for adding the
    `broken` label, `not_broken/*` for removing the `broken` label, or `token_reset/*`
    for token resets)
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.


@conda-forge/conda-index 
