### PR TITLE
Add request to archive pandas-profiling

### DIFF
--- a/requests/pandas-profiling.yml
+++ b/requests/pandas-profiling.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - cf-autotick-bot-test-package

--- a/requests/pandas-profiling.yml
+++ b/requests/pandas-profiling.yml
@@ -1,3 +1,3 @@
 action: archive
 feedstocks:
-  - cf-autotick-bot-test-package
+  - pandas-profiling


### PR DESCRIPTION
## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

pandas-profiling has been deprecated and replaced by [ydata-profiling](https://github.com/ydataai/ydata-profiling).

This [issue](https://github.com/conda-forge/pandas-profiling-feedstock/issues/51) has been raised in the feedstock.