### PR TITLE
Mark micromamba 2 alpha releases a broken

### DIFF
--- a/requests/micromamba2alpha.yml
+++ b/requests/micromamba2alpha.yml
@@ -1,0 +1,14 @@
+action: broken
+packages:
+- win-64/micromamba-2.0.0alpha1-1.tar.bz2
+- osx-arm64/micromamba-2.0.0alpha1-1.tar.bz2
+- osx-64/micromamba-2.0.0alpha1-1.tar.bz2
+- linux-ppc64le/micromamba-2.0.0alpha1-1.tar.bz2
+- linux-aarch64/micromamba-2.0.0alpha1-1.tar.bz2
+- linux-64/micromamba-2.0.0alpha1-1.tar.bz2
+- linux-aarch64/micromamba-2.0.0alpha1-0.tar.bz2
+- win-64/micromamba-2.0.0alpha1-0.tar.bz2
+- osx-64/micromamba-2.0.0alpha1-0.tar.bz2
+- osx-arm64/micromamba-2.0.0alpha1-0.tar.bz2
+- linux-ppc64le/micromamba-2.0.0alpha1-0.tar.bz2
+- linux-64/micromamba-2.0.0alpha1-0.tar.bz2


### PR DESCRIPTION
The alpha candidates of micromamba are now listed in `https://api.anaconda.org/release/conda-forge/micromamba/latest`, which is mirrored and used in production environments. Moving the alpha candidates to the broken channel should fix this, until we find a way to filter alpha releases from `latest` mirrors.
