### PR TITLE
mark _0 build of fmt 10.2.0 as broken on windows

### DIFF
--- a/requests/fmt.yml
+++ b/requests/fmt.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- win-64/fmt-10.2.0-h181d51b_0.conda


### PR DESCRIPTION
This is a follow-up of an unintentional ABI-break in fmt 10.2 that caused mamba to break, see https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/628.

However, upstream merged a fix that restores the missing symbol, and we already have new builds for that on the fmt feedstock: https://github.com/conda-forge/fmt-feedstock/pull/42

This marks `_0` as broken on windows (the missing symbol isn't used on unix), which will allow to keep using the major-level ABI-pinning of `fmt`.

CC @jaimergp @saraedum @bdice