### PR TITLE
Mark old deltalake linux-64 0.15.x builds broken

### DIFF
--- a/requests/deltalake-015x-broken.yml
+++ b/requests/deltalake-015x-broken.yml
@@ -1,0 +1,12 @@
+action: broken
+packages:
+- linux-64/deltalake-0.15.0-py38hfe96bc9_0.conda
+- linux-64/deltalake-0.15.0-py310h8fc3409_0.conda
+- linux-64/deltalake-0.15.0-py39hccdef0e_0.conda
+- linux-64/deltalake-0.15.0-py311hf42d015_0.conda
+- linux-64/deltalake-0.15.0-py312hd892df0_0.conda
+- linux-64/deltalake-0.15.1-py310h8fc3409_0.conda
+- linux-64/deltalake-0.15.1-py39hccdef0e_0.conda
+- linux-64/deltalake-0.15.1-py38hfe96bc9_0.conda
+- linux-64/deltalake-0.15.1-py312hd892df0_0.conda
+- linux-64/deltalake-0.15.1-py311hf42d015_0.conda


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

Due to some combination of https://github.com/conda-forge/conda-smithy/issues/1827 and https://github.com/PyO3/maturin/issues/1911, the initial builds of deltalake 0.15.x for linux-64 contained no members, tracked by https://github.com/conda-forge/deltalake-feedstock/issues/18.

This has now been resolved for 0.15.1 with https://github.com/conda-forge/deltalake-feedstock/pull/20, and it doesn't seem like there's a strong desire to backport this fix to 0.15.0.

cc @dhirschfeld

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
