### PR TITLE
Mark azure-core-cpp 1.11 broken on linux

### DIFF
--- a/requests/azure-core-cpp-1-11.yml
+++ b/requests/azure-core-cpp-1-11.yml
@@ -1,0 +1,11 @@
+action: broken
+packages:
+  - linux-64/azure-core-cpp-1.11.0-h22d5011_0.conda
+  - linux-64/azure-core-cpp-1.11.0-hd64b3e6_0.conda
+  - linux-64/azure-core-cpp-1.11.0-h91d86a7_0.conda
+  - linux-aarch64/azure-core-cpp-1.11.0-haf42898_0.conda
+  - linux-aarch64/azure-core-cpp-1.11.0-hc0db439_0.conda
+  - linux-aarch64/azure-core-cpp-1.11.0-hcd87347_0.conda
+  - linux-ppc64le/azure-core-cpp-1.11.0-h0c291d7_0.conda
+  - linux-ppc64le/azure-core-cpp-1.11.0-he7d803c_0.conda
+  - linux-ppc64le/azure-core-cpp-1.11.0-hfc5fd81_0.conda


### PR DESCRIPTION
See https://github.com/conda-forge/tiledb-feedstock/issues/228#issuecomment-1890919858 for context. This latest release breaks tiledb (which doesn't have a strict pin on the azure-core-cpp version, just <2), and in that way also breaks eg libgdal.

In our CI where we noticed this, it's only on Linux that we see the crash, not on Windows or Mac. Therefore I only marked the linux packages as broken. We only test linux-64, but I marked aarch64 and pplc as well (assuming those would have the same issue?)

cc @conda-forge/azure-core-cpp 

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
