### PR TITLE
Request to remove broken build 0 of xarray-2023.10.0

### DIFF
--- a/requests/xarray_2023_10_0_build_0-broken.yml
+++ b/requests/xarray_2023_10_0_build_0-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+  - noarch/xarray-2023.10.0-pyhd8ed1ab_0.conda


### PR DESCRIPTION

Hello,

I would like to report the build 0  of xarray-2023.10.0 as broken. However I am not sure if a meta data patch or the deletion of the package is the correct proceedure. There are two builds of the version (xarray-2023.10.0) which only differ in there dependency meta data. (numpy >=1.21 and numpy >=1.22 respectively)
 
https://github.com/conda-forge/xarray-feedstock/commit/7047d15b508b860bd71eb2d231d921e5c699a87b

Should the meta data still be patched even though build 0 and 1 are exactly the same then when patched?

All the best,

Julian

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
