### PR TITLE
mark older builds of kim-api-2.3.0 as broken

### DIFF
--- a/requests/kim-api-2.3.0-broken.yml
+++ b/requests/kim-api-2.3.0-broken.yml
@@ -1,0 +1,9 @@
+action: broken
+packages:
+- osx-arm64/kim-api-2.3.0-h08610c0_0.conda
+- osx-64/kim-api-2.3.0-hb20c0b4_0.conda
+- linux-64/kim-api-2.3.0-h94b5c5c_0.conda
+- linux-aarch64/kim-api-2.3.0-h5a3f854_0.conda
+- osx-64/kim-api-2.3.0-h32d3758_0.tar.bz2
+- osx-arm64/kim-api-2.3.0-h9c9afe6_0.tar.bz2
+- linux-64/kim-api-2.3.0-h0911212_0.tar.bz2


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

We have recently added the ability to build models to the kim-api conda-forge package. This is not a new functionality of the KIM API, it just was not present in the conda-forge package. This involved adding compilers (e.g. {{ compiler('c') }}, etc.) and build tools as run requirements, as well as a modification to the build script in order to set paths to compilers through CMake (so this is not just a metadata deficiency).

Because older builds of kim-api-2.3.0 don't have these dependencies, the solver will preferentially install them if any conflicting versions of the compilers are present in the environment. This is confusing to users, who expect the fixed model-building functionality to be present in their environment, but it is not because they accidentally obtained an older build without any warning. Because of this, we think it's appropriate to mark the older builds as broken (after all, they are missing functionality they're supposed to have). I think just marking the 2.3.0 builds as broken is sufficient, this way we can unambiguously instruct users to install kim-api=2.3.0

I've already discussed this with [kim-api-feedstock](https://github.com/conda-forge/kim-api-feedstock) developers @jan-janssen @ellio167

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
