### PR TITLE
request archive of jupyter_sphinx feedstock

### DIFF
--- a/requests/archive-jupyter_sphinx.yml
+++ b/requests/archive-jupyter_sphinx.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - jupyter_sphinx


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

I am a new maintainer of the jupyter-sphinx package and by setting up the badges in the readme file I realized there are 2 feedstocks wired to the same package..

we have:

https://github.com/conda-forge/jupyter_sphinx-feedstock
https://github.com/conda-forge/jupyter-sphinx-feedstock


I would like to only keep the "jupyter-sphinx" one to use the same naming convention as in the pypi package.
What we did is to refactor the "jupyter-sphinx" recipe to create 2 outputs and avoid breaking the existing environment relying on "jupyter_sphinx" (https://github.com/conda-forge/jupyter-sphinx-feedstock/pull/9) and then use "jupyter_sphinx" as an alias for jupyter-sphinx (https://github.com/conda-forge/feedstock-outputs/pull/56). 

Now it seems the last step is to archive the jupyter_sphinx repository definitively so we only continue to maintain the correct one.

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

ping @conda-forge/jupyter_sphinx 
