### PR TITLE
Mark nbstripout 0.7.0 broken

### DIFF
--- a/requests/broken.yml
+++ b/requests/broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/nbstripout-0.7.0-pyhd8ed1ab_0.conda


### PR DESCRIPTION
nbstripout version 0.7.0 is broken due to a major regression, truncating input files before they are read (see kynan/nbstripout#190). This regression makes this release practically unusable.

I'm the maintainer of both https://github.com/kynan/nbstripout and https://github.com/conda-forge/nbstripout-feedstock.
