### PR TITLE
Mark ArcticDB 4.3.0 as broken

### DIFF
--- a/requests/arcticdb-broken.yml
+++ b/requests/arcticdb-broken.yml
@@ -1,0 +1,15 @@
+action: broken
+packages:
+- linux-64/arcticdb-4.3.0-py310h7d25564_1.conda
+- linux-64/arcticdb-4.3.0-py311hb408ad7_1.conda
+- linux-64/arcticdb-4.3.0-py38h4b8a820_1.conda
+- linux-64/arcticdb-4.3.0-py39h13e1746_1.conda
+- linux-64/arcticdb-4.3.0-py39h51d9f5e_1.conda
+- linux-64/arcticdb-4.3.0-py39hce34a90_1.conda
+- osx-arm64/arcticdb-4.3.0-py310h7edaf50_1.conda
+- osx-arm64/arcticdb-4.3.0-py39hfd49b1e_1.conda
+- osx-arm64/arcticdb-4.3.0-py311h967b865_1.conda
+- osx-64/arcticdb-4.3.0-py39h3df0ab6_1.conda
+- osx-64/arcticdb-4.3.0-py310h4104312_1.conda
+- osx-64/arcticdb-4.3.0-py311hc8922a7_1.conda
+


### PR DESCRIPTION
I'm one of the maintainers for the ArcticDB project.

We want to mark the 4.3.0 release, which was made yesterday, as broken due to a fairly severe bug in the release, that means it should not be used.

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [ x ] I want to mark a package as broken (or not broken):
  * [ x ] Added a description of the problem with the package in the PR description.
  * [ x ] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
