### PR TITLE
Reset Azure token for `loopy`

### DIFF
--- a/requests/loopy_token_reset.yml
+++ b/requests/loopy_token_reset.yml
@@ -1,0 +1,4 @@
+action: token_reset
+feedstocks:
+- loopy
+skip_providers: [azure]


### PR DESCRIPTION
Seeing issues uploading: https://github.com/conda-forge/loopy-feedstock/pull/6#issuecomment-1949935801

Also looks like the PR template no longer has a reset token option?