### PR TITLE
Change one last `pkg` to `feedstock`

### DIFF
--- a/conda_forge_admin_requests/token_reset.py
+++ b/conda_forge_admin_requests/token_reset.py
@@ -138,7 +138,7 @@ def run(request):
                 "failed to reset token for '%s': %s" % (feedstock, repr(e)),
                 flush=True,
             )
-            feedstocks_to_do_again.append(pkg)
+            feedstocks_to_do_again.append(feedstock)
 
     if feedstocks_to_do_again:
         request = copy.deepcopy(request)


### PR DESCRIPTION
Looks like all the `pkg` variables were renamed to `feedstock` in PR ( https://github.com/conda-forge/admin-requests/pull/921 ), but there was a stray one

This resulted in an issue resetting a token: https://github.com/conda-forge/admin-requests/pull/939#issuecomment-1949938245