### PR TITLE
Add missing `import copy` to token reset script

### DIFF
--- a/conda_forge_admin_requests/token_reset.py
+++ b/conda_forge_admin_requests/token_reset.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import sys
 import glob


### PR DESCRIPTION
Ran into a missing `import` here: https://github.com/conda-forge/admin-requests/pull/940#issuecomment-1949941110

This adds the `import`