### PR TITLE
Mark broken compiled "noarch" builds of `r-parallelly`

### DIFF
--- a/requests/r-parallelly-broken.yml
+++ b/requests/r-parallelly-broken.yml
@@ -1,0 +1,4 @@
+action: broken
+packages:
+- noarch/r-parallelly-1.37.0-r42hc72bb7e_0.conda
+- noarch/r-parallelly-1.37.0-r43hc72bb7e_0.conda


### PR DESCRIPTION
The last round of autoticked builds of `r-parallelly` didn't catch that upstream switched from `noarch` to compiled. The recipe [has been updated](https://github.com/conda-forge/r-parallelly-feedstock/pull/24). This marks the mislabelled `noarch` builds as broken (resolves https://github.com/conda-forge/r-parallelly-feedstock/issues/25).

ping @conda-forge/r-parallelly 

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.
