### PR TITLE
enable tensorflow to use cirun

### DIFF
--- a/requests/tensorflow.yaml
+++ b/requests/tensorflow.yaml
@@ -1,0 +1,8 @@
+action: cirun
+feedstocks:
+  - tensorflow
+resources:
+  - cirun-openstack-cpu-large
+pull_request: true
+revoke: false
+send_pr: true


### PR DESCRIPTION
Tensorflow has long been stuck in CFEP-03 land, let's try to get it out of there. ;-)

CC @jaimergp @isuruf @hmaarrfk @xhochy 