### PR TITLE
enable mongodb to use cirun

### DIFF
--- a/requests/mongodb.yaml
+++ b/requests/mongodb.yaml
@@ -1,0 +1,8 @@
+action: cirun
+feedstocks:
+  - mongodb
+resources:
+  - cirun-openstack-cpu-large
+pull_request: true
+revoke: false
+send_pr: true


### PR DESCRIPTION
Current mongodb v7 manages to compile about half the objects before running into the 6h timecap ([example](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=882735&view=results); around `[2385+2/4544]` on linux-64, `[2398+2/4489]` on win-64, etc.) - completely hopeless to get it over the line.

CC @jaimergp 
