### PR TITLE
Mark glib build with proxy-libintl as broken

### DIFF
--- a/requests/glib.yml
+++ b/requests/glib.yml
@@ -1,0 +1,20 @@
+action: broken
+packages:
+  - osx-64/glib-2.78.4-h92b6c6a_1.conda
+  - win-64/glib-2.78.4-h4dfd0cc_1.conda
+  - osx-arm64/glib-2.78.4-h091b4b1_1.conda
+  - linux-64/glib-2.78.4-h2797004_1.conda
+  - linux-aarch64/glib-2.78.4-h194ca79_1.conda
+  - linux-ppc64le/glib-2.78.4-hd4bbf49_1.conda
+  - osx-64/glib-tools-2.78.4-h92b6c6a_1.conda
+  - win-64/glib-tools-2.78.4-h4dfd0cc_1.conda
+  - osx-arm64/glib-tools-2.78.4-h091b4b1_1.conda
+  - linux-64/glib-tools-2.78.4-h2797004_1.conda
+  - linux-aarch64/glib-tools-2.78.4-h194ca79_1.conda
+  - linux-ppc64le/glib-tools-2.78.4-hd4bbf49_1.conda
+  - osx-64/libglib-2.78.4-h89b4d22_1.conda
+  - win-64/libglib-2.78.4-h55e6270_1.conda
+  - osx-arm64/libglib-2.78.4-hbf44286_1.conda
+  - linux-64/libglib-2.78.4-h4648e47_1.conda
+  - linux-aarch64/libglib-2.78.4-h2afc65d_1.conda
+  - linux-ppc64le/libglib-2.78.4-h6f8e791_1.conda


### PR DESCRIPTION
These builds contain a proxy implementation of `libintl` (which is actually part of `gettext`) and thus break all packages that were previously build against `libglib`. See also https://github.com/conda-forge/glib-feedstock/issues/162 We cannot repodata patch as the respective library should never be installed.

cc @conda-forge/glib 


<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
