### PR TITLE
Mark non-cross gcc/gxx*_2 as broken

### DIFF
--- a/requests/gcc_gxx_all.yml
+++ b/requests/gcc_gxx_all.yml
@@ -1,0 +1,26 @@
+action: broken
+packages:
+  - linux-64/gcc_linux-64-12.3.0-h6477408_2.conda
+  - linux-64/gcc_linux-64-11.4.0-h0f0c6b6_2.conda
+  - linux-64/gcc_linux-64-13.2.0-h1ed452b_2.conda
+  - linux-s390x/gxx_linux-s390x-13.2.0-hcade943_2.conda
+  - linux-s390x/gxx_linux-s390x-11.4.0-h022e620_2.conda
+  - linux-s390x/gxx_linux-s390x-12.3.0-ha827a15_2.conda
+  - linux-ppc64le/gxx_linux-ppc64le-11.4.0-hb963a8d_2.conda
+  - linux-ppc64le/gxx_linux-ppc64le-13.2.0-h9e68a72_2.conda
+  - linux-ppc64le/gxx_linux-ppc64le-12.3.0-h9f0faa2_2.conda
+  - linux-aarch64/gxx_linux-aarch64-13.2.0-he4e47f3_2.conda
+  - linux-aarch64/gxx_linux-aarch64-12.3.0-h3d1e521_2.conda
+  - linux-aarch64/gxx_linux-aarch64-11.4.0-h27552d9_2.conda
+  - linux-64/gxx_linux-64-13.2.0-he8deefe_2.conda
+  - linux-64/gxx_linux-64-12.3.0-h4a1b8e8_2.conda
+  - linux-64/gxx_linux-64-11.4.0-h2730b16_2.conda
+  - linux-s390x/gcc_linux-s390x-13.2.0-h7b30c7b_2.conda
+  - linux-s390x/gcc_linux-s390x-11.4.0-h6d560d7_2.conda
+  - linux-s390x/gcc_linux-s390x-12.3.0-hf33dac9_2.conda
+  - linux-ppc64le/gcc_linux-ppc64le-11.4.0-hfbdc564_2.conda
+  - linux-ppc64le/gcc_linux-ppc64le-13.2.0-h3729aa9_2.conda
+  - linux-ppc64le/gcc_linux-ppc64le-12.3.0-he284332_2.conda
+  - linux-aarch64/gcc_linux-aarch64-13.2.0-hf42520a_2.conda
+  - linux-aarch64/gcc_linux-aarch64-12.3.0-h9622932_2.conda
+  - linux-aarch64/gcc_linux-aarch64-11.4.0-hd664738_2.conda


### PR DESCRIPTION
They don't have a run_exports, cc @isuruf @h-vetinari 