### PR TITLE
PyDTMC Broken Packages

### DIFF
--- a/requests/pydtmc-broken.yml
+++ b/requests/pydtmc-broken.yml
@@ -1,0 +1,5 @@
+action: broken
+packages:
+- noarch/pydtmc-8.2.0-pyhd8ed1ab_0.conda
+- noarch/pydtmc-8.1.0-pyhd8ed1ab_0.conda
+- noarch/pydtmc-6.7.0-pyhd8ed1ab_0.tar.bz2


### PR DESCRIPTION
## Checklist:

* [X] I want to mark a package as broken (or not broken):
  * [X] Added a description of the problem with the package in the PR description.
  * [X] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed


Hi @conda-forge/pydtmc
    please move the specified packages from main to broken on the conda-forge channel. The reason is that I recently checked all the past releases and I found out that those packages are unusable because of a bad setup, which I cannot recover.