### PR TITLE
Mark graphite2-1.3.13-*_1002 Windows package as broken

### DIFF
--- a/requests/graphite2-broken.yml
+++ b/requests/graphite2-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- win-64/graphite2-1.3.13-h57928b3_1002.conda


### PR DESCRIPTION
`conda create -n ffmpeg ffmpeg` On Windows currently results in a broken package, and similarly `import cv2` crashes, as harfbuzz can't find `graphite2.dll`. The package contain a file called `libgraphite2.dll` instead, as I guess it was compiled with mingw. See https://github.com/conda-forge/graphite2-feedstock/issues/14 for more details, however I think it is a good idea to just mark it as broken to fix all the library that depends on harfbuzz.

cc @conda-forge/ffmpeg @conda-forge/opencv @conda-forge/harfbuzz @conda-forge/graphite2 


## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.


