### PR TITLE
Mark snappy 1.2.0 as broken

### DIFF
--- a/requests/snappy-broken.yml
+++ b/requests/snappy-broken.yml
@@ -1,0 +1,9 @@
+action: broken
+packages:
+- win-64/snappy-1.2.0-hfb803bf_0.conda
+- osx-arm64/snappy-1.2.0-hd04f947_0.conda
+- osx-64/snappy-1.2.0-h6dc393e_0.conda
+- linux-aarch64/snappy-1.2.0-h8d0c38d_0.conda
+- linux-ppc64le/snappy-1.2.0-h26b3661_0.conda
+- linux-64/snappy-1.2.0-hdb0a2a9_0.conda
+


### PR DESCRIPTION
See https://github.com/conda-forge/snappy-feedstock/issues/35 for context. Snappy 1.2.0, although providing the same .so version as 1.1.10, changed some APIs leading to broken imports in packages built against snappy (eg pyarrow)

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
