### PR TITLE
mark c-blosc2 2.14 as broken

### DIFF
--- a/requests/c-blosc2.yml
+++ b/requests/c-blosc2.yml
@@ -1,0 +1,22 @@
+action: broken
+packages:
+  - linux-64/c-blosc2-2.14.0-hb4ffafa_0.conda
+  - linux-64/c-blosc2-2.14.1-hb4ffafa_0.conda
+  - linux-64/c-blosc2-2.14.3-hb4ffafa_0.conda
+  - linux-64/c-blosc2-2.14.4-hb4ffafa_0.conda
+  - osx-64/c-blosc2-2.14.0-h0ae8482_0.conda
+  - osx-64/c-blosc2-2.14.1-h0ae8482_0.conda
+  - osx-64/c-blosc2-2.14.3-h0ae8482_0.conda
+  - osx-64/c-blosc2-2.14.4-h0ae8482_0.conda
+  - osx-arm64/c-blosc2-2.14.0-ha57e6be_0.conda
+  - osx-arm64/c-blosc2-2.14.1-ha57e6be_0.conda
+  - osx-arm64/c-blosc2-2.14.3-ha57e6be_0.conda
+  - osx-arm64/c-blosc2-2.14.4-ha57e6be_0.conda
+  - linux-aarch64/c-blosc2-2.14.0-h1a8d543_0.conda
+  - linux-aarch64/c-blosc2-2.14.1-h1a8d543_0.conda
+  - linux-aarch64/c-blosc2-2.14.3-h1a8d543_0.conda
+  - linux-aarch64/c-blosc2-2.14.4-h1a8d543_0.conda
+  - linux-ppc64le/c-blosc2-2.14.0-ha09d7d1_0.conda
+  - linux-ppc64le/c-blosc2-2.14.1-ha09d7d1_0.conda
+  - linux-ppc64le/c-blosc2-2.14.3-ha09d7d1_0.conda
+  - linux-ppc64le/c-blosc2-2.14.4-ha09d7d1_0.conda


### PR DESCRIPTION
SO version was wrong until 2.14.4, run_exports too loose until 2.14.4_1

references:

- https://github.com/conda-forge/c-blosc2-feedstock/issues/62
- fixed build for 2.14.4: https://github.com/conda-forge/c-blosc2-feedstock/pull/66