### PR TITLE
mark ioos_metrics as broken

### DIFF
--- a/requests/example-broken.yml
+++ b/requests/example-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+  - noarch/ioos_metrics-0.1.0.dev0-pyhd8ed1ab_0.conda


### PR DESCRIPTION
We renamed it upstream and we don't want folks installing this one by mistake.