### PR TITLE
enable larger GPU runners on pytorch feedstock

### DIFF
--- a/examples/pytorch-gpu.yml
+++ b/examples/pytorch-gpu.yml
@@ -9,3 +9,4 @@ resources:
   - cirun-openstack-cpu-large
 pull_request: true
 revoke: false
+send_pr: false

--- a/examples/pytorch-gpu.yml
+++ b/examples/pytorch-gpu.yml
@@ -1,0 +1,11 @@
+action: cirun
+feedstocks:
+  - pytorch-cpu
+resources:
+  - cirun-openstack-gpu-4xlarge
+  - cirun-openstack-gpu-2xlarge
+  - cirun-openstack-gpu-xlarge
+  - cirun-openstack-gpu-large
+  - cirun-openstack-cpu-large
+pull_request: true
+revoke: false


### PR DESCRIPTION
This expands on #881 because we run out of memory on the cirun server. Based on [observed](https://github.com/conda-forge/pytorch-cpu-feedstock/pull/237#issuecomment-2113388516) memory usage from building locally, it has been suggested to try the 4xl runner; I'm also enabling the intermediate ones in case those en up as sufficient.

Needed for https://github.com/conda-forge/pytorch-cpu-feedstock/pull/238