### PR TITLE
Declare latest namaster build as broken

### DIFF
--- a/requests/namaster_broken.yml
+++ b/requests/namaster_broken.yml
@@ -1,0 +1,14 @@
+action: broken
+packages:
+- osx-64/namaster-1.6-py39h75cff2b_6.conda
+- osx-arm64/namaster-1.6-py312h09e2779_6.conda
+- osx-64/namaster-1.6-py312h5bb63be_6.conda
+- osx-arm64/namaster-1.6-py311hdaedbd2_6.conda
+- osx-64/namaster-1.6-py311hfcee9fe_6.conda
+- osx-64/namaster-1.6-py310h0d88b9a_6.conda
+- osx-arm64/namaster-1.6-py310h27ec7fe_6.conda
+- osx-arm64/namaster-1.6-py39hf4085c4_6.conda
+- linux-64/namaster-1.6-py39h9b489bb_6.conda
+- linux-64/namaster-1.6-py310h59d84b5_6.conda
+- linux-64/namaster-1.6-py312h31119b3_6.conda
+- linux-64/namaster-1.6-py311h65b8726_6.conda


### PR DESCRIPTION
## Context
The latest namaster [build](https://github.com/conda-forge/namaster-feedstock/pull/42) updated it to numpy v2. This is not yet a stable numpy release, and some of the changes are actually not compatible with namaster and some of its current dependencies.

ping @conda-forge/namaster 

## Checklist:

* [x] I want to mark a package as broken (or not broken):
* [x] Added a description of the problem with the package in the PR description.
* [x] Pinged the team for the package for their input.