### PR TITLE
add xformers to cirun

### DIFF
--- a/requests/xformers.yml
+++ b/requests/xformers.yml
@@ -1,0 +1,8 @@
+action: cirun
+feedstocks:
+  - xformers
+resources:
+  - cirun-openstack-gpu-xlarge
+pull_request: true  
+revoke: false
+send_pr: true

--- a/requests/xformers.yml
+++ b/requests/xformers.yml
@@ -2,7 +2,7 @@ action: cirun
 feedstocks:
   - xformers
 resources:
-  - cirun-openstack-gpu-xlarge
+  - cirun-openstack-cpu-xlarge
 pull_request: true  
 revoke: false
 send_pr: true


### PR DESCRIPTION
xformers compiles a lot of symbols per architecture, and times out with our default set of architectures, which _should_ look like this:
```bash
    if [[ ${cuda_compiler_version} == 11.8 ]]; then
        export TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9+PTX"
    elif [[ ${cuda_compiler_version} == 12.0 ]]; then
        export TORCH_CUDA_ARCH_LIST="5.0;6.0;6.1;7.0;7.5;8.0;8.6;8.9;9.0+PTX"
```
To avoid timing out with the 6h limit on azure, we're currently just able to build
```bash
    if [[ ${cuda_compiler_version} == 11.8 ]]; then
        export TORCH_CUDA_ARCH_LIST="5.0;8.9+PTX"
    elif [[ ${cuda_compiler_version} == 12.0 ]]; then
        export TORCH_CUDA_ARCH_LIST="5.0;7.0;8.0;9.0+PTX"
```
i.e. 2-4 instead of 9 GPU architectures. I think it would be good to build the full set of architectures on the cirun server. Shouldn't need a particularly beefy machine, just more time.

CC @jaimergp @isuruf @jakirkham @conda-forge/xformers