### PR TITLE
Archive `libusb1`, `iosbackup`, `mvt`

### DIFF
--- a/requests/archive.yml
+++ b/requests/archive.yml
@@ -1,0 +1,5 @@
+action: archive
+feedstocks:
+  - libusb1
+  - iosbackup
+  - mvt


### PR DESCRIPTION
Archive the following feedstocks due to maintainer inactivity. The currently provided versions are outdated and not functional on modern systems:

- `libusb1`, https://github.com/conda-forge/libusb1-feedstock/issues/4
- `iosbackup`, https://github.com/conda-forge/iosbackup-feedstock/issues/3
- `mvt`, https://github.com/conda-forge/mvt-feedstock/issues/23


## Checklist:

* [ ] I want to mark a package as broken (or not broken):
  * [ ] Added a description of the problem with the package in the PR description.
  * [ ] Pinged the team for the package for their input.

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
