### PR TITLE
mark riskfolio-lib “noarch” packages as broken

### DIFF
--- a/requests/riskfolio-lib-broken.yml
+++ b/requests/riskfolio-lib-broken.yml
@@ -1,0 +1,4 @@
+action: broken
+packages:
+- noarch/riskfolio-lib-4.1.0-pyh10c408e_1.conda
+- noarch/riskfolio-lib-4.1.0-pyhff85662_0.conda


### PR DESCRIPTION
riskfolio-lib 4.1.0 is compiled but erroneously marked as noarch https://anaconda.org/conda-forge/riskfolio-lib/files

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed
