### PR TITLE
feat: runs feedstock generation when `recipe.yaml` exists

### DIFF
--- a/.github/workflows/create_feedstocks.yml
+++ b/.github/workflows/create_feedstocks.yml
@@ -2,7 +2,7 @@ name: create_feedstocks
 
 on:
   schedule:
-    - cron: "*/10 * * * *"
+    - cron: '*/10 * * * *'
   workflow_dispatch: null
 
 jobs:

--- a/.github/workflows/create_feedstocks.yml
+++ b/.github/workflows/create_feedstocks.yml
@@ -2,7 +2,7 @@ name: create_feedstocks
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: "*/10 * * * *"
   workflow_dispatch: null
 
 jobs:
@@ -42,7 +42,9 @@ jobs:
         if: ${{ steps.conversion_lock.outcome == 'success' }}
         run: |
           # Avoid wasting CI time if there are no recipes ready for conversion
-          if [ "$(ls recipes/*/meta.yaml | grep -v recipes/example/meta.yaml --count)" -eq 0 ]; then
+          # Checks for both `meta.yaml` and `recipe.yaml` files in the recipes directory
+          # Excludes the example recipe(s)
+          if [ "$(ls recipes/*/meta.yaml recipes/*/recipe.yaml 2>/dev/null | grep -vE 'recipes/example/meta.yaml|recipes/example/recipe.yaml' --count)" -eq 0 ]; then
             echo "No new recipes found, exiting..."
             exit 0
           fi


### PR DESCRIPTION
This PR add support to run the feedstock generation when a rattler-build `recipe.yaml` file is found. I've just expanded the `if` clause to these cases.

I think this PR should be merged **after**: https://github.com/conda-forge/staged-recipes/pull/26981
So I'll make a draft of it till that one is merged.

Let me know if I'm missing something, happy to make any changes.