### PR TITLE
Mark rattler-build-compat-broken as broken

### DIFF
--- a/requests/rattler-build-compat-broken.yml
+++ b/requests/rattler-build-compat-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/rattler-build-conda-compat-0.1.2-pyhd8ed1ab_0.conda


### PR DESCRIPTION
See https://github.com/conda-forge/rattler-build-conda-compat-feedstock/issues/11

We can't patch repodata since building that requires building a feedstock and all feedstocks are broken right now.

cc @conda-forge/rattler-build-conda-compat 