### PR TITLE
mark the RDKit MacOS 2024.3.4 build 1 packages as broken

### DIFF
--- a/requests/rdkit-broken.yml
+++ b/requests/rdkit-broken.yml
@@ -1,0 +1,12 @@
+action: broken
+packages:
+- osx-arm64/rdkit-2024.03.4-py39h1e940ea_1.conda
+- osx-arm64/rdkit-2024.03.4-py38h85cd035_1.conda
+- osx-arm64/rdkit-2024.03.4-py312h5e647cc_1.conda
+- osx-arm64/rdkit-2024.03.4-py311hefbf022_1.conda
+- osx-arm64/rdkit-2024.03.4-py310h35840a8_1.conda
+- osx-64/rdkit-2024.03.4-py39h7e99098_1.conda
+- osx-64/rdkit-2024.03.4-py38ha31138a_1.conda
+- osx-64/rdkit-2024.03.4-py312hc58cafc_1.conda
+- osx-64/rdkit-2024.03.4-py311ha2b1ff4_1.conda
+- osx-64/rdkit-2024.03.4-py310h76b7c8c_1.conda


### PR DESCRIPTION
## Description of the problem

An update to the conda-forge version of `libcxx` triggered a bug in some very basic functionality within the rdkit packages on MacOS (intel and arm64), rendering those packages unuseable for many people.

This PR will remove build 1 of these MacOS packages, leaving build 0, which used the older version of `libcxx` and so doesn't trigger the bug.

More context and a link to the upstream fixes here:
https://github.com/conda-forge/rdkit-feedstock/issues/162

This will, unfortunately, remove the numpy 2.0 compatible RDKit builds for MacOS.
We're also doing an upstream release today so that we can get an up-to-date RDKit version (with numpy 2.0 support) out there for all systems.

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

