### PR TITLE
Use Miniforge, not Mambaforge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,20 +37,18 @@ jobs:
             echo "CI_SKIP=true" >> $GITHUB_ENV
           fi
 
-      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v2
+      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
         if: steps.conversion_lock.outcome == 'success' && ! env.CI_SKIP
         with:
           activate-environment: cf
           environment-file: environment.yml
           auto-activate-base: true
           miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: true
 
       - name: Generate token
         if: steps.conversion_lock.outcome == 'success' && ! env.CI_SKIP
         id: generate_token
-        uses: actions/create-github-app-token@ad38cffc07bac6e3857755914c4c88bfd2db4da4 # v1
+        uses: actions/create-github-app-token@ad38cffc07bac6e3857755914c4c88bfd2db4da4 # v1.10.2
         with:
           app-id: ${{ secrets.CF_CURATOR_APP_ID }}
           private-key: ${{ secrets.CF_CURATOR_PRIVATE_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,13 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v2
+      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
         with:
           activate-environment: cf
           environment-file: environment.yml
           auto-activate-base: true
           miniforge-version: latest
-          miniforge-variant: Mambaforge
 
       - name: Check request YAML files
         shell: bash -el {0}

--- a/.github/workflows/repodata_patching.yml
+++ b/.github/workflows/repodata_patching.yml
@@ -22,14 +22,13 @@ jobs:
         # outcome is evaluated before continue-on-error above
         if: steps.conversion_lock.outcome == 'success'
 
-      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v2
+      - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
         if: steps.conversion_lock.outcome == 'success'
         with:
           activate-environment: cf
           environment-file: environment.yml
           auto-activate-base: true
           miniforge-version: latest
-          miniforge-variant: Mambaforge
 
       - name: Generate token
         if: steps.conversion_lock.outcome == 'success'


### PR DESCRIPTION
Comes from https://github.com/conda-forge/miniforge/issues/602#issuecomment-2248188930

We were using Mambaforge and not Miniforge, but they should be equivalent.

Also fixed the version comments of some GHA hash pins.