### PR TITLE
add next-larger runner for mongodb

### DIFF
--- a/requests/mongodb.yaml
+++ b/requests/mongodb.yaml
@@ -1,0 +1,9 @@
+action: cirun
+feedstocks:
+  - mongodb
+resources:
+  - cirun-openstack-cpu-large
+  - cirun-openstack-cpu-xlarge
+pull_request: true
+revoke: false
+send_pr: false


### PR DESCRIPTION
Follow-up to #949.

Despite reduced parallelism, https://github.com/conda-forge/mongodb-feedstock/pull/80 keeps dying from running into what appears to be an OOM issue (c.f. https://github.com/Quansight/open-gpu-server/issues/28).

Try with the next-larger runner (not sure why this isn't listed in the [.cirun](https://github.com/conda-forge/.cirun) readme, https://github.com/conda-forge/.cirun/issues/19).

CC @jaimergp @isuruf