### PR TITLE
Request large CPU/GPU runners for flash-attn

### DIFF
--- a/requests/flash-attn-open-gpu-server.yml
+++ b/requests/flash-attn-open-gpu-server.yml
@@ -1,0 +1,8 @@
+action: cirun
+feedstocks:
+  - flash-attn
+resources:
+  - cirun-openstack-gpu-large
+pull_request: true
+revoke: false
+send_pr: true

--- a/requests/flash-attn-open-gpu-server.yml
+++ b/requests/flash-attn-open-gpu-server.yml
@@ -3,6 +3,7 @@ feedstocks:
   - flash-attn
 resources:
   - cirun-openstack-gpu-large
+  - cirun-openstack-cpu-large
 pull_request: true
 revoke: false
 send_pr: true


### PR DESCRIPTION
Applying for `cirun-openstack-gpu-large` and `cirun-openstack-cpu-large` for building flash-attn. Builds were originally using `TORCH_CUDA_ARCH_LIST=8.0+PTX` only to try to keep under 6 hour limit at https://github.com/conda-forge/staged-recipes/pull/26239, but they recently started to timeout at https://github.com/conda-forge/flash-attn-feedstock/pull/10.

Using a bigger instance will also allow us to build for `TORCH_CUDA_ARCH_LIST=8.0;8.6;8.9;9.0+PTX`, xref https://github.com/conda-forge/flash-attn-feedstock/issues/4

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->


## Checklist:

* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [x] Added a small description explaining why access is needed

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
