### PR TITLE
Mark pytorch 2.4.0 osx + mkl build 0 as broken

### DIFF
--- a/requests/pytorch_osx_mkl_240-broken.yml
+++ b/requests/pytorch_osx_mkl_240-broken.yml
@@ -1,0 +1,12 @@
+action: broken
+packages:
+- osx-64/pytorch-2.4.0-cpu_mkl_py38h56ac713_100.conda
+- osx-64/pytorch-2.4.0-cpu_mkl_py39he10d680_100.conda
+- osx-64/pytorch-2.4.0-cpu_mkl_py310heb6a33a_100.conda
+- osx-64/pytorch-2.4.0-cpu_mkl_py311hb8f3093_100.conda
+- osx-64/pytorch-2.4.0-cpu_mkl_py312h105ce57_100.conda
+- osx-64/libtorch-2.4.0-cpu_mkl_h3ccab0b_100.conda
+- osx-64/libtorch-2.4.0-cpu_mkl_h2fda0bb_100.conda
+- osx-64/libtorch-2.4.0-cpu_mkl_hcc88766_100.conda
+- osx-64/libtorch-2.4.0-cpu_mkl_hc3937cb_100.conda
+- osx-64/libtorch-2.4.0-cpu_mkl_ha973b97_100.conda


### PR DESCRIPTION
xref: https://github.com/conda-forge/numpy-feedstock/issues/327
xref: https://github.com/conda-forge/pytorch-cpu-feedstock/pull/252

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
