### PR TITLE
Mark vs 19.41 as not broken

### DIFF
--- a/requests/vs.yml
+++ b/requests/vs.yml
@@ -1,0 +1,6 @@
+action: not_broken
+packages:
+- win-64/vs2022_win-64-19.41.34120-h72b6792_20.conda
+- win-arm64/vs2022_win-64-19.41.34120-h2222f22_20.conda
+- win-64/vs2022_win-arm64-19.41.34120-hc5d368c_20.conda
+- win-arm64/vs2022_win-arm64-19.41.34120-h067b14d_20.conda


### PR DESCRIPTION
## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

---

cc: @isuruf, @h-vetinari, @conda-forge/vc 

Undoes #1056 

The Azure Windows Server 2022 image has been switching back and forth between Visual Studio 17.10 (19.40) and 17.11 (19.41). Currently it is back to image version 20240825.1.0, which requires vs2022_win-64 19.41. Hopefully Azure keeps the image version stable going forward

xref: https://github.com/actions/runner-images/pull/10490, https://github.com/conda-forge/vc-feedstock/pull/82#issuecomment-2313344988, https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/133#issuecomment-2313329076