### PR TITLE
qubovert file broken

### DIFF
--- a/requests/qubovert-broken.yml
+++ b/requests/qubovert-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/qubovert-1.2.5-pyh6d1e4d8_0.conda


### PR DESCRIPTION
It seems when qubovert is installed with conda it throws an error when attempting to import python-c code.

On windows:
> {
> 	"name": "ModuleNotFoundError",
> 	"message": "No module named 'qubovert.sim._canneal'",
> 	"stack": "---------------------------------------------------------------------------
> ModuleNotFoundError                       Traceback (most recent call last)
> Cell In[1], line 1
> ----> 1 from qubovert import PUBO, boolean_var
> 
> File c:\\Users\\h.karhula\\src\\mqt-qao\\.pixi\\envs\\default\\Lib\\site-packages\\qubovert\\__init__.py:55
>      45 __all__ = (
>      46     __all_qubo__ +
>      47     __all_quso__ +
>    (...)
>      51     __all_pcso__
>      52 )
>      54 from . import sat
> ---> 55 from . import sim
>      56 from . import problems
>      59 del __all_qubo__, __all_quso__
> 
> File c:\\Users\\h.karhula\\src\\mqt-qao\\.pixi\\envs\\default\\Lib\\site-packages\\qubovert\\sim\\__init__.py:24
>      22 from ._anneal_temperature_range import *
>      23 from ._anneal_results import *
> ---> 24 from ._anneal import *
>      26 from ._anneal_temperature_range import __all__ as __all_tr__
>      27 from ._anneal_results import __all__ as __all_results__
> 
> File c:\\Users\\h.karhula\\src\\mqt-qao\\.pixi\\envs\\default\\Lib\\site-packages\\qubovert\\sim\\_anneal.py:30
>      28 import numpy as np
>      29 from itertools import chain
> ---> 30 from ._canneal import c_anneal_quso, c_anneal_puso
>      33 __all__ = (
>      34     'anneal_qubo', 'anneal_quso', 'anneal_pubo', 'anneal_puso',
>      35     'SCHEDULES'
>      36 )
>      38 SCHEDULES = 'linear', 'geometric'
> 
> ModuleNotFoundError: No module named 'qubovert.sim._canneal'"
> }

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours. 

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [ ] I want to mark a package as broken (or not broken):
  * [ ] Added a description of the problem with the package in the PR description.
  * [ ] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
