### PR TITLE
Mark vs 19.41 as broken (again)

### DIFF
--- a/requests/vs.yml
+++ b/requests/vs.yml
@@ -1,0 +1,6 @@
+action: broken
+packages:
+- win-64/vs2022_win-64-19.41.34120-h72b6792_20.conda
+- win-arm64/vs2022_win-64-19.41.34120-h2222f22_20.conda
+- win-64/vs2022_win-arm64-19.41.34120-hc5d368c_20.conda
+- win-arm64/vs2022_win-arm64-19.41.34120-h067b14d_20.conda


### PR DESCRIPTION
## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

---

The transition from Visual Studio 17.10 to 17.11 for the Azure image windows-2022 has been extremely frustrating. At least twice now they have migrated to Visual Studio 17.11 but then rolled back to 17.10. These decisions are not made publicly. The only public facing PR is to update the documentation, which has been merged, even though the image has not been deployed to Azure yet (https://github.com/actions/runner-images/pull/10490#issuecomment-2321358956).

It's not possible to pin the image version (https://github.com/actions/runner-images/discussions/3464), and apparently there is no way for the conda-forge vc recipe to install the correct version based on the available version of Visual Studio (https://github.com/conda-forge/vc-feedstock/pull/82#issuecomment-2315619084). Thus our only option is to mark the latest `vs2022_win-64` as broken or not broken depending on what Azure image version is deployed on any given day (#1056, #1058).

Our win-64 builds are currently blocked by this (https://github.com/conda-forge/tiledb-feedstock/issues/340), and there is no indication that Azure will deploy the new image anytime soon. Thus I propose marking them as broken (yet again) to unblock our builds. I can send a follow-up PR to mark them as unbroken once Azure finally deploys the new image long term.

cc: @isuruf, @h-vetinari, @conda-forge/vc