### PR TITLE
Expand globs for known versioned ouputs

### DIFF
--- a/.feedstock_outputs_autoreg_allowlist.yml
+++ b/.feedstock_outputs_autoreg_allowlist.yml
@@ -6,9 +6,19 @@
 # are interpreted by Python's `fnmatch` module.
 atkmm:
   - atkmm-*
+clangdev:
+  - clang-*
+  - clang-format-*
+  - libclang*
+  - libclang-cpp*
+llvm-spirv:
+  - libllvmspirv*
+  - llvm-spirv-*
 llvmdev:
   - libllvm*
   - libllvm-c*
   - llvm-tools-*
+mlir:
+  - libmlir*
 staged-recipes:
   - "blah-*"  # this entry allows us to do testing of the webservices do not remove

--- a/.feedstock_outputs_autoreg_allowlist.yml
+++ b/.feedstock_outputs_autoreg_allowlist.yml
@@ -4,11 +4,11 @@
 # useful for feedstocks like `llvmdev` whose output names change in defined
 # ways over time (e.g., `libllvm18`, `libllvm19`, etc.). The glob patterns
 # are interpreted by Python's `fnmatch` module.
-staged-recipes:
-  - "blah-*"  # this entry allows us to do testing of the webservices do not remove
-llvmdev:
-  - libllvm*
-  - llvm-tools-*
-  - libllvm-c*
 atkmm:
   - atkmm-*
+llvmdev:
+  - libllvm*
+  - libllvm-c*
+  - llvm-tools-*
+staged-recipes:
+  - "blah-*"  # this entry allows us to do testing of the webservices do not remove


### PR DESCRIPTION
Follow-up from #1074 
> @beckermr: I added a few items to start. We can add more over time as we hit things. They are hard to track down a priori.

There's a bunch more using [this search](https://github.com/search?q=org%3Aconda-forge+%2F-+name%3A%5Cs%5Cw%2B%5C%7B%5C%7B%2F+path%3Arecipe%2Fmeta.yaml&type=code&p=1), but for now I'm not adding all these (for `vc14_runtime`, `vs2022_win-64`, etc. I didn't add it because it should be extremely rare to touch this)