### PR TITLE
label as broken non-noarch `r-betareg` artifacts

### DIFF
--- a/requests/r-betareg-broken.yml
+++ b/requests/r-betareg-broken.yml
@@ -1,0 +1,7 @@
+action: broken
+packages:
+- noarch/r-betareg-3.2_1-r43hc72bb7e_0.conda
+- noarch/r-betareg-3.2_1-r44hc72bb7e_0.conda
+- noarch/r-betareg-3.2_0-r43hc72bb7e_1.conda
+- noarch/r-betareg-3.2_0-r44hc72bb7e_1.conda
+- noarch/r-betareg-3.2_0-r43hc72bb7e_0.conda


### PR DESCRIPTION
The `r-betareg` package [added some compiled components from v3.1-4 to v3.2-0](https://github.com/cran/betareg/compare/3.1-4...3.2-0), but this was not caught until https://github.com/conda-forge/r-betareg-feedstock/pull/18. Hence, there are some uploaded artifacts that are labeled as **noarch**, but are in fact **linux-64**. This PR marks them as broken.

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

ping @conda-forge/r-betareg 
