### PR TITLE
Delete pysimplegui 5

### DIFF
--- a/requests/pysimplegui.yml
+++ b/requests/pysimplegui.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+  - noarch/pysimplegui-5.0.4-pyhd8ed1ab_0.conda


### PR DESCRIPTION
cc @conda-forge/pysimplegui 

See the reasoning here: https://github.com/conda-forge/pysimplegui-feedstock/issues/83

Keeping this simply as broken could bring us into legal trouble. If this PR is merged, I would manually delete the package as we don't have automation for it.

@conda-forge/core Deleting a package is drastic but required from my PoV. Let's get more than one approval here given its drastic nature (and to keep a positive mood in core).