### PR TITLE
mark noarch mpi metapackages broken

### DIFF
--- a/requests/mpi-broken.yml
+++ b/requests/mpi-broken.yml
@@ -1,0 +1,8 @@
+action: broken
+packages:
+- noarch/mpi-1.0-msmpi.conda
+- noarch/mpi-1.0-mvapich.conda
+- noarch/mpi-1.0-openmpi.conda
+- noarch/mpi-1.0-impi.conda
+- noarch/mpi-1.0-mpi_serial.conda
+- noarch/mpi-1.0-mpich.conda


### PR DESCRIPTION
these cause problems in conda due to a bug in conda not handling x.y versions in noarch packages

https://github.com/conda-forge/mpi-feedstock/issues/17

The `1.0.1` builds don't appear to have this problem

cc @leofang 