### PR TITLE
Mark some older python windows freethreading builds as broken

### DIFF
--- a/requests/python.yml
+++ b/requests/python.yml
@@ -1,0 +1,5 @@
+action: broken
+packages:
+- win-64/python-3.13.0rc2-h4077693_2_cp313t.conda
+- win-64/python-3.13.0rc2-h4077693_1_cp313t.conda
+- win-64/python-3.13.0rc2-h4077693_0_cp313t.conda


### PR DESCRIPTION
@conda-forge/core @conda-forge/python these didn't have some files and for some reason, these builds gets picked up.