### PR TITLE
Archive pyqmix

### DIFF
--- a/requests/archive-pyqmix.yml
+++ b/requests/archive-pyqmix.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - pyqmix


### PR DESCRIPTION
Following a suggestion by @beckermr, I'd like to request the archiving of the pyqmix feedstock, as the upstream project has been archived as well and doesn't receive updates any longer.

## Checklist:

* [ ] I want to mark a package as broken (or not broken):
  * [ ] Added a description of the problem with the package in the PR description.
  * [ ] Pinged the team for the package for their input.

* [x] I want to archive a feedstock:
  * [x] <strike>Pinged the team for that feedstock for their input.</strike> I'm the package maintainer (both upstream and on conda-forge)
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description: https://github.com/conda-forge/pyqmix-feedstock/issues/23
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [ ] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description of why the output is being added.
