### PR TITLE
Unarchive XZ feedstock

### DIFF
--- a/requests/unarchive_xz.yml
+++ b/requests/unarchive_xz.yml
@@ -1,0 +1,3 @@
+action: unarchive
+feedstocks:
+  - xz


### PR DESCRIPTION
The xz feedstock was archived quite some time ago during the code-injection security issue. This has been resolved in version 5.6.2. Since then 5.6.3 was released, which contains another windows cli security fix:  https://github.com/tukaani-project/xz/releases. I think we should start building releases here again (and also maybe change the sourcecode source in the feedstock).

I am not part of the xz-feedstock team and no expert on xz.

* [ ] I want to unarchive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  
 ping @conda-forge/xz 
