### PR TITLE
archive gym feedstock

### DIFF
--- a/requests/gym.yml
+++ b/requests/gym.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - gym


### PR DESCRIPTION
For reasoning see https://github.com/conda-forge/gym-feedstock/issues/39. The package got renamed and moved to https://github.com/conda-forge/gymnasium-feedstock, but more importantly, it also messes up the dependency graph. In sum, let's archive it.