### PR TITLE
chore: reset token for repodata patches

### DIFF
--- a/requests/cfrp.yml
+++ b/requests/cfrp.yml
@@ -1,0 +1,3 @@
+action: token_reset
+feedstocks:
+  - conda-forge-repodata-patches-feedstock


### PR DESCRIPTION
This PR resets the tokens for the repodata patches so we can run it on gha.