### PR TITLE
archive hdk feedstock

### DIFF
--- a/requests/hdk.yml
+++ b/requests/hdk.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - hdk


### PR DESCRIPTION
The upstream https://github.com/intel/hdk has been archived in May, and the feedstock has been a magnet for dead and/or unresolvable migration PRs for over a year already.

@leshikus of the @conda-forge/hdk team [asked](https://github.com/conda-forge/hdk-feedstock/pull/57#issuecomment-2405712319)

> What is the process of retiring the feedstock?

So let's just accept that this ~parrot~ feedstock is dead.