### PR TITLE
Add new unified memory framework component to oneAPI DPC++ repack

### DIFF
--- a/requests/intel-compiler-repack-add-umf.yml
+++ b/requests/intel-compiler-repack-add-umf.yml
@@ -1,4 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
   # this entry adds a package name
-  - intel-compiler-repack: "umf-*"
+  - intel-compiler-repack: umf


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

---

@conda-forge/intel-compiler-repack 

This PR adds Unified-Memory-Framework conda package to the allowed outputs of intel-compiler-repack-feedstock to unblock update to 2025.0 version in https://github.com/conda-forge/intel-compiler-repack-feedstock/pull/52