### PR TITLE
Add etspy-gpu package to etspy feedstock

### DIFF
--- a/requests/add-feedstock-output.yml
+++ b/requests/add-feedstock-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # this entry adds a package name
+  - etspy: etspy-gpu


### PR DESCRIPTION


## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s): ping @conda-forge/python 
  * [x] Added a small description of why the output is being added.
    * Adding another package name to allow for easy installation of optional GPU-calculation packages that are not required by the primary package

As an aside, this is the first time I've done this, so I may have it wrong, but `etspy` is the feedstock name, and `etspy-gpu` is the desired new package name.