### PR TITLE
request to mark packages with release candidate (linux/x86_64) as broken.

### DIFF
--- a/requests/scip-920-rc.yml
+++ b/requests/scip-920-rc.yml
@@ -1,3 +1,6 @@
 action: broken
 packages:
 - linux-64/scip-9.2.0-h445098e_0.conda
+- linux-64/soplex-7.1.2-habd59de_0.conda
+- linux-64/papilo-2.4.0-he395102_0.conda
+- linux-64/gcg-3.7.0-hf8b0789_0.conda

--- a/requests/scip-920-rc.yml
+++ b/requests/scip-920-rc.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- linux-64/scip-9.2.0-h445098e_0.conda


### PR DESCRIPTION
I did a mistake in https://github.com/conda-forge/scipoptsuite-feedstock/pull/76, which uploaded a Linux build for a release candidate of packages for SCIP Optimization Suite 9.2.0 (scip 9.2.0, soplex 7.1.2, papilo 2.4.0, gcg 3.7.0) to conda-forge.

Closes conda-forge/scipoptsuite-feedstock#80.

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.


ping @conda-forge/scipoptsuite-feedstock 
