### PR TITLE
Add ittapi-static package

### DIFF
--- a/requests/ittapi-add-feedstock-output.yml
+++ b/requests/ittapi-add-feedstock-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # this entry adds a package name
+  - ittapi: ittapi-static


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/ittapi

I want to add `ittapi-static` package in addition to `ittapi`. It seems like `ittapi` was created as python package, but there is an option to have a static library that can be used by other projects. For example, I intent to use it intel-pti, but I've seen similar requests from folks.

Changes introduced in the PR: https://github.com/conda-forge/ittapi-feedstock/pull/34

It also looks like the feedstock does not have active maintainers, so I'm requesting to add myself there: https://github.com/conda-forge/ittapi-feedstock/pull/33
