### PR TITLE
Add intel-pti package

### DIFF
--- a/requests/pti-gpu-unitrace-add-feedstock-output.yml
+++ b/requests/pti-gpu-unitrace-add-feedstock-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # this entry adds a package name
+  - pti-gpu-unitrace: intel-pti


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/pti-gpu-unitrace 

Intel recently release `intel-pti` package in https://software.repos.intel.com/python/conda channel. This package is important cause it is required dependency for the intel's gpu (aka xpu) backend for pytorch. Instead of adding it as a repack at https://github.com/conda-forge/intel_repack-feedstock it is possible to build it from source here:
https://github.com/conda-forge/pti-gpu-unitrace-feedstock/pull/1

`pti-gpu-unitrace` does not have independent release cycle, so we will get regular updates on this as well.