### PR TITLE
add `pyright-node` output to `pyright`

### DIFF
--- a/requests/add-pyright-node.yaml
+++ b/requests/add-pyright-node.yaml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - pyright: pyright-node


### PR DESCRIPTION
ping @conda-forge/pyright 

The `pyright` feedstock currently packages a small Python wrapper around the `pyright` language server (written in TypeScript) that provides a CLI and LSP interface to the TypeScript package. However, the TypeScript code itself is not packaged in the feedstock. This causes the package to run an npm install in the background on its first invocation, requiring internet access.

In https://github.com/conda-forge/pyright-feedstock/pull/184, I've added pyright-node as a feedstock output. This packages the JavaScript code, making the `pyright` package self-contained and removing the need for the npm install at runtime.