### PR TITLE
mark latest rattler-build build on win as broken

### DIFF
--- a/requests/rattler-build-windows.yml
+++ b/requests/rattler-build-windows.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+-  win-64/rattler-build-0.30.0-h49672d7_1.conda


### PR DESCRIPTION
Unfortunately the latest rattler-build build is empty on Windows. Will debug now.

<img width="1095" alt="Screenshot 2024-11-17 at 10 31 56" src="https://github.com/user-attachments/assets/f60c508e-ad45-4c47-aed6-a9613c03ae78">
