### PR TITLE
Request token reset for `flask-security`

### DIFF
--- a/requests/flask-security.yml
+++ b/requests/flask-security.yml
@@ -1,0 +1,3 @@
+action: token_reset
+feedstocks:
+- flask-security


### PR DESCRIPTION
Ref: https://github.com/conda-forge/flask-security-feedstock/pull/7

Failing with:

```
+ validate_recipe_outputs flask-security-feedstock
WARNING: No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.26
Adding in variants from internal_defaults
Adding in variants from /home/conda/feedstock_root/.ci_support/linux_64_.yaml
validation results:
{
  "noarch/flask-security-5.5.2-pyhff2d567_0.conda": false
}
```

Did the previous checks, but seems the feedstock has been inactive for a number of years and just recently got a new version, which might explain why the token reset might be needed.

