### PR TITLE
enable clang_impl outputs on ctng-compiler-activation

### DIFF
--- a/requests/ctng.yml
+++ b/requests/ctng.yml
@@ -1,0 +1,9 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - ctng-compiler-activation:
+      clang_impl_linux-64
+      clang_impl_linux-aarch64
+      clang_impl_linux-ppc64le
+      clangxx_impl_linux-64
+      clangxx_impl_linux-aarch64
+      clangxx_impl_linux-ppc64le


### PR DESCRIPTION
Now that we have CFEP-24, the new `clang{,xx}_impl` outputs from https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/131 are failing validation. Add them.