### PR TITLE
Allow secondary output due to upstream name change

### DIFF
--- a/requests/name_change_eth-account
+++ b/requests/name_change_eth-account
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # this entry adds a package name
+  - eth-account: eth_account


### PR DESCRIPTION
Upstream renamed the package from using dash to underscore. Thus I added a new output, which needs permission to be uploaded.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s) (I am the feedstock team)
  * [x] Added a small description of why the output is being added.

@conda-forge/eth-account 
