### PR TITLE
Add ergocub-models output for ergocub-software

### DIFF
--- a/requests/ergocub-software.yml
+++ b/requests/ergocub-software.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - ergocub-software: "ergocub-models"


### PR DESCRIPTION
This PR adds the `ergocub-models` output for the `ergocub-software` feedstock. The `ergocub-models` contains the robot models (in XML format) that used to be part of the `libergocub-software` package, they are split so they can be used without the heavy C++ dependencies of the  `libergocub-software` package, see https://github.com/conda-forge/ergocub-software-feedstock/pull/7 for more details.


## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

@conda-forge/ergocub-software  (even if I am the only mantainer of the feedstock)
