### PR TITLE
Request token_reset for cycamore

### DIFF
--- a/requests/cycamore.yml
+++ b/requests/cycamore.yml
@@ -1,0 +1,3 @@
+action: token_reset
+feedstocks:
+- cycamore


### PR DESCRIPTION
Output validation is failing with:
```
Validating outputs
+ validate_recipe_outputs ''
validation results:
{
  "osx-arm64/cycamore-dev-py312hde6d9c8_2.conda": false
}
NOTE: Any outputs marked as False are not allowed for this feedstock. See https://conda-forge.org/docs/maintainer/infrastructure/#output-validation-and-feedstock-tokens for information on how to address this error.
```

I [PR'ed conda-forge-pinning](https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6681) for arm64 mac support but an automated PR was never opened as it was in a different project I maintain. I'm not sure if a token reset will fix this issue but I am following the guidance from the validation failure message. 