### PR TITLE
request token reset for pyarrow

### DIFF
--- a/requests/pyarrow.yml
+++ b/requests/pyarrow.yml
@@ -1,0 +1,3 @@
+action: token_reset
+feedstocks:
+- pyarrow


### PR DESCRIPTION
Due to https://github.com/conda-forge/pyarrow-feedstock/issues/115; a retrigger of the webservice by Matt didn't help, so let's rotate the tokens.