### PR TITLE
add glob for spacy-models

### DIFF
--- a/requests/spacy-models.yml
+++ b/requests/spacy-models.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # this entry adds an allowed glob pattern
+  - spacy-models: "spacy-models-*"


### PR DESCRIPTION
Spacy models has an elaborate setup where new languages (resulting in new `spacy-models-*` packages) get [added](https://github.com/conda-forge/spacy-models-feedstock/blob/main/recipe/conda_build_config.yaml.j2) based on upstream configuration.

Reflect this in the allowed-package outputs.