### PR TITLE
Add astropy-base output to astropy-feedstock

### DIFF
--- a/requests/astropy-base.yml
+++ b/requests/astropy-base.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - astropy: astropy
+  - astropy: astropy-base

--- a/requests/astropy-base.yml
+++ b/requests/astropy-base.yml
@@ -1,4 +1,3 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
-  - astropy: astropy
   - astropy: astropy-base


### PR DESCRIPTION
@conda-forge/astropy Would like to split the astropy feedstock into an astropy package with many deps and an astropy-base package with minimal deps.

https://github.com/conda-forge/astropy-feedstock/pull/137

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
