### PR TITLE
prepare to split suitesparse outputs

### DIFF
--- a/requests/split-suitesparse.yml
+++ b/requests/split-suitesparse.yml
@@ -1,0 +1,18 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - suitesparse: libamd
+  - suitesparse: libbtf
+  - suitesparse: libcamd
+  - suitesparse: libccolamd
+  - suitesparse: libcolamd
+  - suitesparse: libcholmod
+  - suitesparse: libcxsparse
+  - suitesparse: libldl
+  - suitesparse: libklu
+  - suitesparse: libparu
+  - suitesparse: librbio
+  - suitesparse: libspex
+  - suitesparse: libspqr
+  - suitesparse: libsuitesparseconfig
+  - suitesparse: libumfpack
+  - suitesparse: suitesparse-mongoose


### PR DESCRIPTION
each library will get its own output, including the addition of suitesparse-mongoose not previously included:

https://github.com/conda-forge/suitesparse-feedstock/pull/98

package names match those in ubuntu (not including the ABI suffix, so libamd, not libamd3)