### PR TITLE
add rdkit cleanup yml

### DIFF
--- a/requests/rdkit-cleanup.yml
+++ b/requests/rdkit-cleanup.yml
@@ -1,0 +1,21 @@
+action: broken
+packages:
+- osx-64/rdkit-Release_2017_09_3-py36_3.tar.bz2
+- osx-64/rdkit-Release_2017_09_3-py35_3.tar.bz2
+- osx-64/rdkit-Release_2017_09_3-py27_3.tar.bz2
+- linux-64/rdkit-Release_2017_09_3-py36_3.tar.bz2
+- linux-64/rdkit-Release_2017_09_3-py27_3.tar.bz2
+- linux-64/rdkit-Release_2017_09_3-py35_3.tar.bz2
+- osx-64/rdkit-Release_2017_09_3-py36_1.tar.bz2
+- osx-64/rdkit-Release_2017_09_3-py35_1.tar.bz2
+- osx-64/rdkit-Release_2017_09_3-py27_1.tar.bz2
+- linux-64/rdkit-Release_2017_09_3-py36_1.tar.bz2
+- linux-64/rdkit-Release_2017_09_3-py27_1.tar.bz2
+- linux-64/rdkit-Release_2017_09_3-py35_1.tar.bz2
+- osx-64/rdkit-Release_2017_09-py36_0.tar.bz2
+- linux-64/rdkit-Release_2017_09-py35_0.tar.bz2
+- linux-64/rdkit-Release_2017_09-py36_0.tar.bz2
+- linux-64/rdkit-Release_2017_09-py27_0.tar.bz2
+- win-64/rdkit-Release_2017_09-py27_0.tar.bz2
+- win-32/rdkit-Release_2017_09-py27_0.tar.bz2
+


### PR DESCRIPTION
I would like to remove the artifacts from two old releases of the RDKit project from the archive.

In the early days of the RDKit feedstock we used a different version naming scheme. Unfortunately whatever logic is being used to pick the most recent version to show considers that newer than the actual versions. It would be nice if that landing page showed the actual current version.

![image](https://github.com/user-attachments/assets/14414a6a-052c-4149-8bb6-fb6ba3174eff)

This makes it look like the project hasn't been updated since 2017 and is a poor user experience.

The two releases that I suggest marking as broken are seven years old.

I am one of the maintainers of the RDKit feedstock and the main developer of the project itself.

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.
