### PR TITLE
Reset token for gz-physics

### DIFF
--- a/requests/gz-physics-token-reset.yml
+++ b/requests/gz-physics-token-reset.yml
@@ -1,0 +1,3 @@
+action: token_reset
+feedstocks:
+- gz-physics


### PR DESCRIPTION
The token seems to have expired: https://github.com/conda-forge/gz-physics-feedstock/issues/55