### PR TITLE
move scipy-typed to scipy-stubs-feedstock

### DIFF
--- a/requests/move-scipy-typed.yml
+++ b/requests/move-scipy-typed.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - scipy-stubs: scipy-typed


### PR DESCRIPTION
* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

x-ref https://github.com/conda-forge/scipy-stubs-feedstock/pull/5 @h-vetinari 