### PR TITLE
mark minizip windows 4.0.7-h9fa1bad_1 as broken

### DIFF
--- a/requests/broken.yml
+++ b/requests/broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+  - win-64/minizip-4.0.7-h9fa1bad_1.conda


### PR DESCRIPTION

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

What is old is new again, same as #1019, the updated minizip build for windows is broken as it has a different name for the dll, which breaks things left and right :(

cc: @rouault

ping @conda-forge/minizip 