### PR TITLE
mark zellij packages as broken

### DIFF
--- a/requests/zellij-broken.yml
+++ b/requests/zellij-broken.yml
@@ -1,0 +1,14 @@
+action: broken
+packages:
+- linux-aarch64/zellij-0.41.2-ha3529ed_1.conda
+- osx-arm64/zellij-0.41.2-h8dba533_1.conda
+- osx-64/zellij-0.41.2-hd2571bf_1.conda
+- linux-64/zellij-0.41.2-h6c30b3d_1.conda
+- linux-aarch64/zellij-0.41.2-ha3529ed_0.conda
+- osx-arm64/zellij-0.41.2-h3b05019_0.conda
+- osx-64/zellij-0.41.2-h371c88c_0.conda
+- linux-64/zellij-0.41.2-h8fae777_0.conda
+- linux-aarch64/zellij-0.41.1-ha3529ed_0.conda
+- osx-arm64/zellij-0.41.1-h3b05019_0.conda
+- osx-64/zellij-0.41.1-h371c88c_0.conda
+- linux-64/zellij-0.41.1-h8fae777_0.conda


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [ ] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

In https://github.com/conda-forge/zellij-feedstock/issues/4 it was reported that all of our `zellij` 0.41 packages are broken because building the package with `cargo` produces a broken executable which unfortunately still passes a basic test but does not actually work.  It seems that we need to be able to target `wasm32-wapi` for it to work, which is currently available for our `rust` feedstock.

`zellij 0.40` does still work, so we can leave that version up.  I will not merge any updates to `zellij` until we've figured out how to build newer versions that actually work, and will also see if I can add a test that will fail if the build is broken.