### PR TITLE
Archive sphinxcontrib-napoleon

### DIFF
--- a/requests/archive-napoleon.yml
+++ b/requests/archive-napoleon.yml
@@ -1,2 +1,3 @@
-action: 'archive'
-feedstocks: ['sphinxcontrib-napoleon']
+action: archive
+feedstocks:
+    - sphinxcontrib-napoleon

--- a/requests/archive-napoleon.yml
+++ b/requests/archive-napoleon.yml
@@ -1,0 +1,2 @@
+action: 'archive'
+feedstocks: ['sphinxcontrib-napoleon']


### PR DESCRIPTION
## Checklist:

* [x] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

per @ocefpaf's request in https://github.com/conda-forge/sphinxcontrib-napoleon-feedstock/pull/6#issuecomment-2559607728. The upstream package has been defunct for a decade, as it was merged to the core of Sphinx 1.3 in 2014.

Best wishes,
Adam