### PR TITLE
Archive `r-gdalutils`

### DIFF
--- a/requests/archive-r-gdalutils.yml
+++ b/requests/archive-r-gdalutils.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - r-gdalutils


### PR DESCRIPTION
The upstream of `r-gdalutils` is unmaintained and has been removed from CRAN. Requesting to archive.

See https://github.com/conda-forge/r-gdalutils-feedstock/issues/12

## Checklist:
* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

ping @conda-forge/r