### PR TITLE
Create pygnome-broken.yml

### DIFF
--- a/requests/pygnome-broken.yml
+++ b/requests/pygnome-broken.yml
@@ -1,0 +1,6 @@
+action: broken
+packages:
+- win-64/pygnome-1.1.14-py312hc6c7e08_1.conda
+- win-64/pygnome-1.1.14-py310h12034eb_1.conda
+- win-64/pygnome-1.1.14-py39ha3851f1_1.conda
+- win-64/pygnome-1.1.14-py311hd39ab0c_1.conda


### PR DESCRIPTION
Windows builds are broken :-(

They won't run with numpy 2 -- *maybe with numpy 1.*,  but we're not sure. We need to mark these as broken at least until we figure it out

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
