### PR TITLE
linux-aarch64 and linux-ppc64le builds of sirius-ms v6.0.7 are broken.

### DIFF
--- a/requests/sirius-ms-6.0.7-broken.yml
+++ b/requests/sirius-ms-6.0.7-broken.yml
@@ -1,0 +1,4 @@
+action: broken
+packages:
+- linux-ppc64le/sirius-ms-6.0.7-h9bafaf7_1.conda
+- linux-aarch64/sirius-ms-6.0.7-hd8d6117_1.conda


### PR DESCRIPTION
## Description

During the Arch Migrator process, new `linux-aarch64` and `linux-ppc64le` packages were created for SIRIUS 6.0.7 (`sirius-ms v6.0.7`). Unfortunately, some platform-dependent Java libraries in SIRIUS 6.0.7 do not support these architectures. Because our tests did not catch this issue, those packages were published but cannot produce usable results. We would therefore like to mark them as broken.

We are now releasing SIRIUS 6.1.0 with improved tests and proper `linux-aarch64` support. However, `linux-ppc64le` remains unsupported and will be disabled in future builds.

For more details, please see:  
[https://github.com/conda-forge/sirius-ms-feedstock/pull/30](https://github.com/conda-forge/sirius-ms-feedstock/pull/30)


<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
