### PR TITLE
Add serpy output

### DIFF
--- a/requests/add-serpy-output.yml
+++ b/requests/add-serpy-output.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - serpy: serpy


### PR DESCRIPTION
Having issues in https://github.com/conda-forge/serpy-feedstock/pull/2. This is an old package with no new builds in the past 7 years. I already tried a token reset in #1267. Error message on the PR is:

```
validation results:
{
  "noarch/serpy-0.3.1-pyhd8ed1ab_1.conda": false
}
```