### PR TITLE
archive doppel-cli

### DIFF
--- a/requests/doppel-cli-archive.yml
+++ b/requests/doppel-cli-archive.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - doppel-cli


### PR DESCRIPTION
Requesting that the `doppel-cli` feedstock be archived.

Following the process at https://conda-forge.org/docs/maintainer/updating_pkgs/#archiving-feedstocks, I've opened an issue (https://github.com/conda-forge/doppel-cli-feedstock/issues/2) and pinged `@conda-forge/core`.

Thank you for your time.

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.
