### PR TITLE
request token reset for dymos-feedstock

### DIFF
--- a/requests/dymos-token-reset.yml
+++ b/requests/dymos-token-reset.yml
@@ -1,0 +1,7 @@
+action: token_reset
+feedstocks:
+- conda-smithy
+# can be a list with azure, travis, circle, drone, appveyor, github_actions
+skip_providers: []
+# we can expire tokens earlier if desired - default is null which is immediately
+# existing_tokens_time_to_expiration: null  # set to an int in seconds to use


### PR DESCRIPTION
I've received the following `invalid feedstock token` error message after processing https://github.com/conda-forge/dymos-feedstock/pull/9

I've tried the first two suggestions, as well as incrementing the build number.  I am now at the third suggestion.

Assistance appreciated.



>Hi [@conda-forge/dymos](https://github.com/orgs/conda-forge/teams/dymos)! This is the friendly automated conda-forge-webservice!
>
> It appears that one or more of your feedstock's packages did not copy from the
> staging channel (cf-staging) to the production channel (conda-forge). :(
>
> This failure can happen for a lot of reasons, including an outdated feedstock
> token or your feedstock not having permissions to upload the given package.
> Below we have put some information about the failure to help you debug it.
>
> Common ways to fix this problem include:
>
> -  Retry the package build and upload by pushing an empty commit to the feedstock.
> - Rerender the feedstock in a PR from a fork of the feedstock and merge.
> - Request a feedstock token reset via our [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#reset-your-feedstock-token).
> - Request that any new packages be added to the allowed outputs for the feedstock
via our [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#add-a-package-output-to-a-feedstock).
> - In rare cases, the package name may change regularly in a well defined way (e.g., libllvm18, libllvm19, etc.).
In this case, you can use our [admin-requests repo](https://github.com/conda-forge/admin-requests?tab=readme-ov-file#add-a-package-output-to-a-feedstock) to add a glob pattern that matches the new package name pattern. We use the Python fnmatch module syntax. Output packages that match these patterns will be automatically registered for your feedstock.
>
> If you have any issues or questions, you can find us on Zulip in the community [channel](https://conda-forge.zulipchat.com/#narrow/channel/457337-general) or you can bump us right here.
>
> error messages:
>
> invalid feedstock token























