### PR TITLE
Archive spyder-memory-profiler feedstock

### DIFF
--- a/requests/spyder-memory-profiler-archive.yml
+++ b/requests/spyder-memory-profiler-archive.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - spyder-memory-profiler


### PR DESCRIPTION
I was the maintainer of the upstream project [spyder-ide/spyder-memory-profiler](https://github.com/spyder-ide/spyder-memory-profiler) until about two years ago, when I decided to archive the project because its main dependency is no longer maintained.

I just realized that the feedstock is still active, so I want to archive the feedstock.

Link to issue on feedstock: conda-forge/spyder-memory-profiler-feedstock#15
Pinging other feedstock maintainers: @conda-forge/spyder-memory-profiler 

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.
