### PR TITLE
add mapping for ray-cgraph

### DIFF
--- a/requests/add-ray-cgraph.yml
+++ b/requests/add-ray-cgraph.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - ray: "ray-*"

--- a/requests/add-ray-cgraph.yml
+++ b/requests/add-ray-cgraph.yml
@@ -1,3 +1,3 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
-  - ray: "ray-*"
+  - ray-packages: "ray-*"


### PR DESCRIPTION

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
@ping @conda-forge/ray-packages 

There is a new feedstock output ray-cgraph for v2.41.0, see https://github.com/conda-forge/ray-packages-feedstock/pull/193