### PR TITLE
revise: archive `oliver-feedstock`

### DIFF
--- a/requests/oliver-archive.yml
+++ b/requests/oliver-archive.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - oliver


### PR DESCRIPTION
## Checklist:

We've stopped maintaining `oliver` in favor of our own execution engine, [`sprocket`](https://github.com/stjude-rust-labs/sprocket). At this point, we're not going to release any more updates, so it makes sense to archive the feedstock. Here is a link to the [Github Issue](https://github.com/conda-forge/oliver-feedstock/issues/22) on the feedstock repository.

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.