### PR TITLE
allow multiple outputs in ncrystal-feedstock

### DIFF
--- a/requests/add_ncrystal_outputs.yml
+++ b/requests/add_ncrystal_outputs.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - ncrystal: "ncrystal-*"


### PR DESCRIPTION

In order to split the C++/library parts of NCrystal from the Python layer, the ncrystal-feedstock needs to be modified to use multiple outputs. So before there was just an "ncrystal" package, but in the future there will be at least "ncrystal-core", "ncrystal-python",  and "ncrystal" packages, where the last will be a metapackage depending on the rest and ensuring synchronisation of versions. In the future the ncrystal-core itself might be split further (into libs, headers, data files), but that is not going to happen in the short term.

I am the maintainer of the ncrystal-feedstock, so I count myself as having been pinged :-)

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
