### PR TITLE
Fix error handling

### DIFF
--- a/conda_forge_admin_requests/feedstock_outputs.py
+++ b/conda_forge_admin_requests/feedstock_outputs.py
@@ -17,7 +17,7 @@ def _add_feedstock_output(
     repo = gh.get_repo("conda-forge/feedstock-outputs")
     try:
         contents = repo.get_contents(_get_sharded_path(pkg_name))
-    except github.UnknownObjectException:
+    except (github.UnknownObjectException, github.GithubException):
         contents = None
 
     if contents is None:


### PR DESCRIPTION
Try this to see if https://github.com/conda-forge/admin-requests/issues/1346 can be fixed. I can reproduce the error locally and I noticed that despite it's a 404 error, pygithub does not raise `github.UnknownObjectException` as documented, but instead raises the base `github.GithubtException`. Something might have changed in recent pygithub versions. I tested this with 2.4.0.

Let's try to merge this and see if it fixes 1346.