### PR TITLE
Archive vtki

### DIFF
--- a/requests/vtki.yml
+++ b/requests/vtki.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - vtki


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Details

cc @conda-forge/vtki archiving [vtki feedstock](https://github.com/conda-forge/vtki-feedstock) per https://github.com/conda-forge/vtki-feedstock/issues/17

vtki was renamed to PyVista nearly 6 years ago and vtki was only supported up to Python 3.7 which is well beyond End of Life

See https://github.com/conda-forge/pyvista-feedstock instead

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.