### PR TITLE
Mark petsc as broken packages

### DIFF
--- a/requests/petsc-broken.yml
+++ b/requests/petsc-broken.yml
@@ -1,0 +1,6 @@
+action: broken
+packages:
+- linux-64/petsc-3.22.3-cuda11_complex_h5ce9cbd_101.conda
+- linux-64/petsc-3.22.3-cuda11_complex_he184e62_101.conda
+- linux-64/petsc-3.22.3-cuda12_complex_h82b52a3_101.conda
+- linux-64/petsc-3.22.3-cuda12_complex_h8442a08_101.conda


### PR DESCRIPTION
I want to mark a package as broken:
This package broke the conda-forge repodata.json for linux-64 as describe in:
https://github.com/conda/conda-build/issues/5608
@conda-forge/petsc
