### PR TITLE
Mark petsc as broken packages for linux-ppc64le and linux-aarch64

### DIFF
--- a/requests/petsc-broken-more-platforms.yml
+++ b/requests/petsc-broken-more-platforms.yml
@@ -1,0 +1,10 @@
+action: broken
+packages:
+- linux-ppc64le/petsc-3.22.3-cuda11_complex_h8664137_101.conda
+- linux-ppc64le/petsc-3.22.3-cuda11_complex_hb46f4f1_101.conda
+- linux-ppc64le/petsc-3.22.3-cuda12_complex_h6cbf526_101.conda
+- linux-ppc64le/petsc-3.22.3-cuda12_complex_hd360954_101.conda
+- linux-aarch64/petsc-3.22.3-cuda11_complex_h909f8b8_101.conda
+- linux-aarch64/petsc-3.22.3-cuda11_complex_haf44ef8_101.conda
+- linux-aarch64/petsc-3.22.3-cuda12_complex_h68c2ff0_101.conda
+- linux-aarch64/petsc-3.22.3-cuda12_complex_h839bf0e_101.conda


### PR DESCRIPTION
I want to mark a package as broken:
This package broke the conda-forge repodata.json for linux-ppc64le and linux-aarch64 as described in:
https://github.com/conda/conda-build/issues/5608
@conda-forge/petsc