### PR TITLE
mark more petsc cuda complex builds broken

### DIFF
--- a/requests/petsc-broken.yml
+++ b/requests/petsc-broken.yml
@@ -1,0 +1,14 @@
+action: broken
+packages:
+- linux-64/petsc-3.22.3-cuda11_complex_h5ce9cbd_102.conda
+- linux-64/petsc-3.22.3-cuda11_complex_he184e62_102.conda
+- linux-64/petsc-3.22.3-cuda12_complex_h82b52a3_102.conda
+- linux-64/petsc-3.22.3-cuda12_complex_h8442a08_102.conda
+- linux-aarch64/petsc-3.22.3-cuda11_complex_h909f8b8_102.conda
+- linux-aarch64/petsc-3.22.3-cuda11_complex_haf44ef8_102.conda
+- linux-aarch64/petsc-3.22.3-cuda12_complex_h68c2ff0_102.conda
+- linux-aarch64/petsc-3.22.3-cuda12_complex_h839bf0e_102.conda
+- linux-ppc64le/petsc-3.22.3-cuda11_complex_h8664137_102.conda
+- linux-ppc64le/petsc-3.22.3-cuda11_complex_hb46f4f1_102.conda
+- linux-ppc64le/petsc-3.22.3-cuda12_complex_h6cbf526_102.conda
+- linux-ppc64le/petsc-3.22.3-cuda12_complex_hd360954_102.conda


### PR DESCRIPTION
same as #1363

merged prematurely before the rattler-build fix has been deployed (waiting for rattler-build 0.35.10, I believe)
