### PR TITLE
request to remove broken package files from diffpy.pdffit2 in conda-forge

### DIFF
--- a/requests/broken-files.yml
+++ b/requests/broken-files.yml
@@ -1,0 +1,6 @@
+action: broken
+packages:
+- noarch/diffpy.pdffit2-1.4.0-pyh1f5dd6c_4.conda
+- noarch/diffpy.pdffit2-1.4.0-pyh1f5dd6c_3.conda
+- noarch/diffpy.pdffit2-1.4.0-pyh1f5dd6c_2.conda
+- noarch/diffpy.pdffit2-1.4.0-pyh1f5dd6c_1.conda


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Description of the problem
A version of the diffpy.pdffit2 package was accidentally uploaded to the no-arch channel two years ago.  Since we don't have a Mac OS arm64 build for the current version of diffpy.pdffit2, when Mac users conda-install this package, they, by default, get this broken package installed with no error message. 

## Checklist:

* [x] I want to mark a package as broken:
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

ping @conda-forge/diffpy.pdffit2

