### PR TITLE
Set pull.rebase = false for global git configs

### DIFF
--- a/.github/workflows/create_feedstocks.yml
+++ b/.github/workflows/create_feedstocks.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           git config --global user.email "chrisburr73+conda-forge-admin@gmail.com"
           git config --global user.name "conda-forge-admin"
+          git config --global pull.rebase false
           git add *
           git commit -am "make sure we have no windows line endings" || exit 0
           for i in `seq 1 5`; do

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           git config --global user.email "79913779+conda-forge-curator[bot]@users.noreply.github.com"
           git config --global user.name "conda-forge-curator[bot]"
+          git config --global pull.rebase false
           python -m conda_forge_admin_requests run
         env:
           PROD_BINSTAR_TOKEN: ${{ secrets.PROD_BINSTAR_TOKEN }}


### PR DESCRIPTION
This is supposed to address the issues observed in https://github.com/conda-forge/admin-requests/pull/1374. We had this line in other workflows, so let's add it everywhere for consistency.