### PR TITLE
doc: update example for outputs

### DIFF
--- a/examples/example-add-feedstock-output.yml
+++ b/examples/example-add-feedstock-output.yml
@@ -2,5 +2,7 @@ action: add_feedstock_output
 feedstock_to_output_mapping:
   # this entry adds a package name
   - clang-compiler-activation: clang_impl_osx-64
+  # this entry adds another output to the same feedstock
+  - clang-compiler-activation: clang_impl_osx-arm64
   # this entry adds an allowed glob pattern
   - llvmdev: "libllvm*"


### PR DESCRIPTION
This PR adds another example line in the file for adding feedstock outputs to make it clear how to list more than one output for a feedstock in a given job.