### PR TITLE
Check type of output names in 'add_feedstock_output' requests

### DIFF
--- a/conda_forge_admin_requests/feedstock_outputs.py
+++ b/conda_forge_admin_requests/feedstock_outputs.py
@@ -88,7 +88,7 @@ def check(request):
             if not isinstance(pkg_name, str):
                 raise ValueError(
                     f"Value for '{feedstock}' entry must be a str (output name, or a glob), "
-                    f"but you provided {pkg_name:!r}".
+                    f"but you provided {pkg_name:!r}."
                 )
             if feedstock.endswith("-feedstock"):
                 feedstock = feedstock[:-10]

--- a/conda_forge_admin_requests/feedstock_outputs.py
+++ b/conda_forge_admin_requests/feedstock_outputs.py
@@ -84,7 +84,12 @@ def check(request):
 
     assert request.get("feedstock_to_output_mapping")
     for req in request["feedstock_to_output_mapping"]:
-        for feedstock, _ in req.items():
+        for feedstock, pkg_name in req.items():
+            if not isinstance(pkg_name, str):
+                raise ValueError(
+                    f"Value for '{feedstock}' entry must be a str (output name, or a glob), "
+                    f"but you provided {pkg_name:!r}".
+                )
             if feedstock.endswith("-feedstock"):
                 feedstock = feedstock[:-10]
 


### PR DESCRIPTION
Prevent misformatted requests like the ones observed in https://github.com/conda-forge/admin-requests/pull/1374