### PR TITLE
Add sdl2 and sdl3 outputs in sdl feedstock

### DIFF
--- a/requests/sdl.yml
+++ b/requests/sdl.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - sdl: sdl2
+  - sdl: sdl3


### PR DESCRIPTION
This PR adds the `sdl2` and `sdl3`output to the [sdl-feedstock](https://github.com/conda-forge/sdl-feedstock).

To follow package manager habits, SDL major version are released with different package name, but following discussion in https://github.com/conda-forge/staged-recipes/pull/29061#issuecomment-2658421352 we manage to reunite all the major version in one feedstock.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
