### PR TITLE
Archive sdl2-feedstock

### DIFF
--- a/requests/archive_sdl2_feedstock.yml
+++ b/requests/archive_sdl2_feedstock.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - sdl2


### PR DESCRIPTION
Following the discussion here: https://github.com/conda-forge/staged-recipes/pull/29061, the recipes for packages `sdl`, `sdl2`, `sdl3` are now all released through the feedstock: https://github.com/conda-forge/sdl-feedstock.

Thus, the feedstock: https://github.com/conda-forge/sdl2-feedstock can be archived as mentioned in the issue: https://github.com/conda-forge/sdl2-feedstock/issues/61.

@dschreij, @matham, @traversaro do you validate the approach ?

## Checklist:
* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.
