### PR TITLE
Mark libiconv 1.18=*_0 on Windows as broken due to a ABI break

### DIFF
--- a/requests/libiconv-broken.yml
+++ b/requests/libiconv-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- win-64/libiconv-1.18-h135ad9c_0.conda


### PR DESCRIPTION
The `libiconv` 1.18=*_0 build on Windows contains an ABI break that creates a problem in pkg-config and due to the use of pkg-config in a activation script, also in the installation of any package that depends (even transitively) on `gdk-pixbuf` . While we look into a fix, the best option is to mark the problematic package as broken. 

Related issues:
* https://github.com/conda-forge/ffmpeg-feedstock/issues/312
* https://github.com/conda-forge/gdk-pixbuf-feedstock/issues/48
* https://github.com/conda-forge/libiconv-feedstock/issues/48
* https://github.com/conda-forge/vtk-feedstock/pull/368



## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.



@conda-forge/core @conda-forge/libiconv  @conda-forge/pkg-config @conda-forge/gdk-pixbuf @conda-forge/vtk @conda-forge/ffmpeg
