### PR TITLE
Mark oneloop v2.2.16 v3.7.1,v3.7.2 and oneloop-static v3.7.2 as broken

### DIFF
--- a/requests/broken-oneloop-and-oneloop-static.yml
+++ b/requests/broken-oneloop-and-oneloop-static.yml
@@ -1,0 +1,17 @@
+action: broken
+packages:
+# oneloop v3.7.1 and v3.7.2
+- osx-64/oneloop-3.7.1-h7cadb0b_0.conda
+- linux-aarch64/oneloop-3.7.1-hd059565_1.conda
+- osx-64/oneloop-3.7.1-h7cadb0b_1.conda
+- osx-arm64/oneloop-3.7.1-hedc7eab_1.conda
+- linux-aarch64/oneloop-3.7.2-hd059565_1.conda
+- osx-64/oneloop-3.7.2-h7cadb0b_1.conda
+- osx-arm64/oneloop-3.7.2-hedc7eab_1.conda
+- linux-aarch64/oneloop-3.7.2-hd059565_2.conda
+- osx-64/oneloop-3.7.2-h7cadb0b_2.conda
+- osx-arm64/oneloop-3.7.2-hedc7eab_2.conda
+# oneloop-static v3.7.2
+- linux-aarch64/oneloop-static-3.7.2-hd059565_2.conda
+- osx-64/oneloop-static-3.7.2-h7cadb0b_2.conda
+- osx-arm64/oneloop-static-3.7.2-hedc7eab_2.conda


### PR DESCRIPTION
* https://github.com/conda-forge/oneloop-feedstock was accidentally building with quad precision enabled for all platforms, even those that didn't support it. So linux-aarch64 and osx builds have incorrectly built binaries.
* Fixed in https://github.com/conda-forge/oneloop-feedstock/pull/6 for build 3.

> [!NOTE]
> Note to future self: The full names of the packages were retrieved programatically with
> 
> ```
> $ curl -s https://api.anaconda.org/package/conda-forge/oneloop | grep basename | grep 3.7.2 | grep 'aarch64\|osx' | awk '{print $NF}' | sed 's/"//g' | sed 's/,//g'
> ```
> There is obviously a cleaner way to do that, but the above works.
> 
> c.f. [conda-forge Zulip conversation](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/Programatically.20get.20full.20names.20for.20marking.20as.20broken/near/501223875) for reference.

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.
   - I am the maintainer for @conda-forge/oneloop

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [ ] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
