### PR TITLE
Refactor LensKit add-on packages

### DIFF
--- a/requests/archive-lenskit-subpackages.yml
+++ b/requests/archive-lenskit-subpackages.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - lenskit-implicit

--- a/requests/lenskit-subpackages.yml
+++ b/requests/lenskit-subpackages.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # this entry adds an allowed glob pattern
+  - lenskit: "lenskit-*"


### PR DESCRIPTION
We have changed how LensKit is packaged upstream, to release a single PyPI package with extras for add-on dependencies, with the intent to package corresponding meta-packages on conda-forge to activate them (e.g. `lenskit[implicit]` is installed by `lenskit-implicit`), similar to how Ray is packaged.

This request archives the one sub-package that had been packaged for conda-forge, and adds the `lenskit-*` sub-package names as valid outputs from the `lenskit` package (which is building in conda-forge/lenskit-feedstock#18).

I am the feedstock team.

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description. (conda-forge/lenskit-implicit-feedstock#3
  * [x] Added links to any other relevant issues/PRs in the PR description.

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

