### PR TITLE
Allow multiple outputs that start with biomechanical-analysis-framework- in the biomechanical-analysis-framework recipe

### DIFF
--- a/requests/biomechanical-analysis-framework.yaml
+++ b/requests/biomechanical-analysis-framework.yaml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - biomechanical-analysis-framework: "biomechanical-analysis-framework-*"


### PR DESCRIPTION
In release 0.2.0 (https://github.com/conda-forge/biomechanical-analysis-framework-feedstock/pull/2),  the biomechanical-analysis-framework library added two outputs that it make sense to package as `biomechanical-analysis-framework-python` and `biomechanical-analysis-framework-kpi`.

To handle this request and possible similar modifications in the future, I think it could make sense to allow all the outputs with `biomechanical-analysis-framework-` prefix to `biomechanical-analysis-framework` feedstock, as anyhow the prefix is not ambigous. If instead you prefer that I explicitly list the requested outputs (now `biomechanical-analysis-framework-python` and `biomechanical-analysis-framework-kpi`, and in the future possibly more) I can listed them explicitly, thanks!

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/biomechanical-analysis-framework

