### PR TITLE
Mark r-geometry osx-arm64 builds as broken

### DIFF
--- a/requests/r-geometry-osx-arm64-broken.yml
+++ b/requests/r-geometry-osx-arm64-broken.yml
@@ -1,0 +1,6 @@
+action: broken
+packages:
+  - osx-arm64/r-geometry-0.5.1-r43h31118f2_0.conda
+  - osx-arm64/r-geometry-0.5.1-r44h31118f2_0.conda
+  - osx-arm64/r-geometry-0.5.2-r43h31118f2_0.conda
+  - osx-arm64/r-geometry-0.5.2-r44h31118f2_0.conda


### PR DESCRIPTION
As reported in https://github.com/conda-forge/r-geometry-feedstock/issues/23, the recently added **osx-arm64** builds were not correctly built. This PR requests affected builds to be marked as broken.

ping @conda-forge/r-geometry 

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
