### PR TITLE
Mark rubin-scheduler 4.0.0_1 as broken

### DIFF
--- a/requests/rubin-scheduler-broken.yml
+++ b/requests/rubin-scheduler-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+  - noarch/rubin-scheduler-4.0.0-pyhd8ed1ab_1.conda


### PR DESCRIPTION
I need to mark rubin-scheduler 4.0.0 build 1 broken. 

Previously rubin-scheduler 4.0.0 was already marked broken. 
However, I merged a bot request in the conda-forge feedstock, where going from astropy to astropy-base in the recipe was suggested. 
I agreed with the suggestion, and the file for the PR was marked as pointing to v3.4.0 of rubin-scheduler, so I thought this would be fine -- and I merged it.

Unfortunately, the result was that the broken 4.0.0 package had a new build created, which is NOT marked as broken. 
So please, can we mark 4.0.0 build 1 as broken as well as the original build 0. 

(this does bring up a question I have -- at some point, I'd like to replace 4.0.0 with a new version, when our downstream consumers are ready for 4.0.0. Will I be able to do this?? Ideally 4.0.0 would never have existed from conda-forge's point of view). 

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

