### PR TITLE
mark ALL kim-api builds that can't build models at runtime as broken

### DIFF
--- a/requests/mark-kim-api-broken.yaml
+++ b/requests/mark-kim-api-broken.yaml
@@ -1,0 +1,24 @@
+action: broken
+packages:
+- osx-64/kim-api-2.2.1-h33e6e43_0.tar.bz2
+- osx-arm64/kim-api-2.2.1-he7901cf_0.tar.bz2
+- osx-64/kim-api-2.2.1-h626c3c9_0.tar.bz2
+- linux-64/kim-api-2.2.1-h5c8ed42_0.tar.bz2
+- osx-64/kim-api-2.2.0-h626c3c9_0.tar.bz2
+- linux-64/kim-api-2.2.0-h5c8ed42_0.tar.bz2
+- osx-64/kim-api-2.1.3-h9ad844d_6.tar.bz2
+- osx-64/kim-api-2.1.3-h723d936_6.tar.bz2
+- linux-64/kim-api-2.1.3-h920f4d6_6.tar.bz2
+- linux-64/kim-api-2.1.3-h7c385c1_6.tar.bz2
+- osx-64/kim-api-2.1.3-hae2fa9c_5.tar.bz2
+- linux-64/kim-api-2.1.3-h920f4d6_5.tar.bz2
+- osx-64/kim-api-2.1.3-h400a6bc_4.tar.bz2
+- linux-64/kim-api-2.1.3-h4333106_4.tar.bz2
+- osx-64/kim-api-2.1.3-h400a6bc_3.tar.bz2
+- linux-64/kim-api-2.1.3-h4333106_3.tar.bz2
+- osx-64/kim-api-2.1.3-h400a6bc_2.tar.bz2
+- linux-64/kim-api-2.1.3-h4333106_2.tar.bz2
+- osx-64/kim-api-2.1.3-h400a6bc_1.tar.bz2
+- linux-64/kim-api-2.1.3-h4333106_1.tar.bz2
+- osx-64/kim-api-2.1.3-h400a6bc_0.tar.bz2
+- linux-64/kim-api-2.1.3-h4333106_0.tar.bz2


### PR DESCRIPTION
We would like to mark ALL older builds of kim-api as broken, for the same reason as we had previously done for older builds of kim-api=2.3.0 only.

From https://github.com/conda-forge/admin-requests/pull/927:

> We have recently added the ability to build models to the kim-api conda-forge package. This is not a new functionality of the KIM API, it just was not present in the conda-forge package. This involved adding compilers (e.g. {{ compiler('c') }}, etc.) and build tools as run requirements, as well as a modification to the build script in order to set paths to compilers through CMake (so this is not just a metadata deficiency).

>Because older builds of kim-api-2.3.0 don't have these dependencies, the solver will preferentially install them if any conflicting versions of the compilers are present in the environment. This is confusing to users, who expect the fixed model-building functionality to be present in their environment, but it is not because they accidentally obtained an older build without any warning. Because of this, we think it's appropriate to mark the older builds as broken (after all, they are missing functionality they're supposed to have). I think just marking the 2.3.0 builds as broken is sufficient, this way we can unambiguously instruct users to install kim-api=2.3.0

We don't want to tell users for the rest of time that they must specify kim-api>=2.3.0 to get a fully functional package, so we would like to extend this to all builds before the model-building fix. The fix involved changes to the build script, so it is not possible to patch the old packages.

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [ ] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description of why the output is being added.

  ping @conda-forge/kim-api 
