### PR TITLE
Archive feedstock & mark broken packages of `vllm-nccl-cu12`

### DIFF
--- a/requests/archive_vllm-nccl-cu12.yml
+++ b/requests/archive_vllm-nccl-cu12.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - vllm-nccl-cu12

--- a/requests/broken_vllm-nccl.yml
+++ b/requests/broken_vllm-nccl.yml
@@ -1,0 +1,4 @@
+action: broken
+packages:
+- noarch/vllm-nccl-cu12-2.18.1.0.4.0-pyh52da0d0_1.conda
+- noarch/vllm-nccl-cu12-2.18.1.0.4.0-pyhd8ed1ab_0.conda


### PR DESCRIPTION
Fixes https://github.com/conda-forge/vllm-nccl-cu12-feedstock/issues/2

`vllm-nccl-cu12` was used to [perform binary redistribution]( https://github.com/vllm-project/vllm-nccl/blob/7bd6f94268858602b42632a010ac44b014ffe4f7/setup.py ) of [the NVIDIA NCCL library]( https://developer.nvidia.com/nccl ) for wheels. However conda-forge does not need this nor should it. Further newer versions of `vllm` do [not need `vllm-nccl-cu12`]( https://github.com/vllm-project/vllm/pull/5091/files ). Hence [the `vllm-nccl` repo was archived]( https://github.com/vllm-project/vllm-nccl )

NVIDIA NCCL supplies [source on GitHub]( https://github.com/NVIDIA/nccl ) under [the BSD-3-Clause license]( https://github.com/NVIDIA/nccl/blob/f44ac759fee12ecb3cc6891e9e739a000f66fd70/LICENSE.txt ). We also build [the NCCL package from source in conda-forge]( https://github.com/conda-forge/nccl-feedstock ). These packages are already in use third-party packages in conda-forge

Currently nothing uses `vllm-nccl-cu12`. When `vllm` is added to conda-forge, it can simply use the `nccl` packages already in conda-forge (as mentioned above). Thus this PR archives the feedstock and marks the packages `broken`.

<hr>

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [ ] I want to mark a package as broken (or not broken):
  * [ ] Added a description of the problem with the package in the PR description.
  * [ ] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [ ] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
