### PR TITLE
Mark pcl=1.15.0=*_1 builds as broken

### DIFF
--- a/requests/pcl-broken.yml
+++ b/requests/pcl-broken.yml
@@ -1,0 +1,8 @@
+action: broken
+packages:
+- osx-64/pcl-1.15.0-h0c9537a_1.conda
+- osx-arm64/pcl-1.15.0-h467ecd0_1.conda
+- linux-ppc64le/pcl-1.15.0-h422e3f3_1.conda
+- linux-64/pcl-1.15.0-hfe7170b_1.conda
+- linux-aarch64/pcl-1.15.0-hf335d11_1.conda
+- win-64/pcl-1.15.0-h4137319_1.conda


### PR DESCRIPTION
Due to a error in the file extension of the manually added migration file in https://github.com/conda-forge/pcl-feedstock/pull/79, the `pcl=1.15.0=*_1` (that should have been built wit vtk 9.4.*) are actually identical to `pcl=1.15.0=*_0` builds, but with wrong metadata, resulting in downstream issues like https://github.com/ami-iit/biomechanical-analysis-framework/issues/69 . 

The upstream fix for the issue is provided in https://github.com/conda-forge/pcl-feedstock, while this PR mark `pcl=1.15.0=*_1` as broken to fix builds that use `vtk=9.3` .

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.
