### PR TITLE
archive bcolz

### DIFF
--- a/requests/bcolz.yml
+++ b/requests/bcolz.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - bcolz

--- a/requests/bcolz.yml
+++ b/requests/bcolz.yml
@@ -1,3 +1,4 @@
 action: archive
 feedstocks:
   - bcolz
+  - zipline


### PR DESCRIPTION
Upstream https://github.com/Blosc/bcolz has been archived for almost 5 years and doesn't support anything past py3.8

There's been no response in https://github.com/conda-forge/bcolz-feedstock/issues/20 for 1.5 years, which is also a good indicator that it's time.