### PR TITLE
Mark tinyxml2 10.1.0 builds as broken

### DIFF
--- a/requests/tinyxml2-broken.yml
+++ b/requests/tinyxml2-broken.yml
@@ -1,0 +1,14 @@
+action: broken
+packages:
+- linux-aarch64/tinyxml2-10.1.0-h5ad3122_1.conda
+- linux-ppc64le/tinyxml2-10.1.0-h2621725_1.conda
+- osx-arm64/tinyxml2-10.1.0-ha1acc90_1.conda
+- osx-64/tinyxml2-10.1.0-h92383a6_1.conda
+- win-64/tinyxml2-10.1.0-he0c23c2_1.conda
+- linux-64/tinyxml2-10.1.0-h3f2d84a_1.conda
+- linux-aarch64/tinyxml2-10.1.0-h5ad3122_0.conda
+- linux-ppc64le/tinyxml2-10.1.0-h2621725_0.conda
+- osx-arm64/tinyxml2-10.1.0-ha1acc90_0.conda
+- win-64/tinyxml2-10.1.0-he0c23c2_0.conda
+- osx-64/tinyxml2-10.1.0-h92383a6_0.conda
+- linux-64/tinyxml2-10.1.0-h3f2d84a_0.conda


### PR DESCRIPTION
This PR proposes to mark as broken the `tinyxml2` 10.1.0 builds, I was and I am still not sure if it make sense to mark them as broken, but I will explain the rationale for marking them as broken in the following.

Shortly after the release of tinyxml2 10.1.0 on conda-forge, we realized that an ABI breakage was present, even if the run_exports of the package assume ABI compatibility for each major version (see https://github.com/conda-forge/tinyxml2-feedstock/issues/16). Right after that, we proceed in updating the `run_exports` of the package to be more tight (https://github.com/conda-forge/tinyxml2-feedstock/pull/21 and https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7151), and added an appropriate repodata patch (https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/972). 

All these changes solved the problem for conda-forge, but then there was a follow up. The upstream project recognized that the 10.1.0 with an ABI break was an error, and re-released 10.1.0 as 11.0.0 (see https://github.com/leethomason/tinyxml2/issues/1018 and https://github.com/leethomason/tinyxml2/releases/tag/11.0.0). Furthermore, we had several tinyxml 10.1.0 releated problems in packages built in [`robostack`](https://robostack.github.io/) channels (if you are not familiar with `robostack`, it is a robotics-specific channel that builds on top of conda-forge, simplifying a lot let's think of it as something like `bioconda` but for robotics), and unfortunately the repodata patches do not apply to downstream channels like `robostack-*` . 

Given these two new events, I think it would be convenient to mark 10.1.0 builds of tinyxml2 as broken, as thanks to https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7151 no package that depends on tinyxml2 10.1.0 was released on conda-forge, and that would solve all problems in downstream channels. This was also suggested as part of a core meeting, see https://github.com/conda-forge/conda-forge.github.io/blob/6a852b662a26aece3b529ab60b56a21bcf0547c6/community/minutes/2025-03-19.md?plain=1#L66 .

On the other hand, the `tinyxml2` 10.1.0 packages on their own are fully working, and on the conda-forge side all problems were fixed by the repodata patches, so I also see why it could make sense not to mark these packages as broken.





## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [ ] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
