### PR TITLE
allow initial flang-rt outputs

### DIFF
--- a/requests/flang-rt.yml
+++ b/requests/flang-rt.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - flang-rt: flang-rt_win-64


### PR DESCRIPTION
This was messed up by the bot between https://github.com/conda-forge/staged-recipes/pull/29582 and the feedstock registration, which ended up ruling out windows completely (needed https://github.com/conda-forge/flang-rt-feedstock/commit/bb26b306dfa516c397ef8cd6ee9452ae38f335fa)