### PR TITLE
allow multiple outputs in mcpl-feedstock

### DIFF
--- a/requests/add_mcpl_outputs.yml
+++ b/requests/add_mcpl_outputs.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - mcpl: "mcpl-*"


### PR DESCRIPTION
For the incoming release 2.0.0 of MCPL (https://github.com/mctools/mcpl) the `mcpl` package is being split into multiple distinct packages (`mcpl-lib`, `mcpl-core`, `mcpl-python`, `mcpl-extra`) with `mcpl` itself simply becoming a meta-package pulling in all the other packages except `mcpl-extra`. This split reflect the current state and how the package is being split up at PyPI, but might of course be modified somewhat in the future, hence the request for a `mcpl-*` glob pattern to be associated with the mcpl-feedstock.

(I am the maintainer of the mcpl-feedstock repo, so I count myself as having been "pinged").

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

