### PR TITLE
Add hyphenated output to universal_pathlib feedstock

### DIFF
--- a/requests/universal_pathlib-add-feedstock-output.yml
+++ b/requests/universal_pathlib-add-feedstock-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - universal_pathlib: universal_pathlib
+  - universal_pathlib: universal-pathlib


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.


ping @conda-forge/universal_pathlib 

This is addressing conda-forge/universal_pathlib-feedstock#45, requesting a meta package `universal-pathlib` to align with pypi behaviour when installing `universal_pathlib`.
