### PR TITLE
Add new outputs nurikit-split/libnurikit to nurikit

### DIFF
--- a/requests/nurikit-add-output.yml
+++ b/requests/nurikit-add-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - nurikit: nurikit-split
+  - nurikit: libnurikit


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

ping @conda-forge/nurikit

This splits build into python-independent c++ library (libnurikit) and the python bindings (nurikit, previous name).

See conda-forge/nurikit-feedstock#7 and seoklab/nurikit#479, and seoklab/nurikit#481.