### PR TITLE
Allow multiple outputs that start with torchcodec- in the torchcodec feedstock

### DIFF
--- a/requests/torchcodec.yaml
+++ b/requests/torchcodec.yaml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - torchcodec: "torchcodec-*"

--- a/requests/torchcodec.yaml
+++ b/requests/torchcodec.yaml
@@ -1,3 +1,3 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
-  - torchcodec: "torchcodec-*"
+  - torchcodec: "torchcodec-tests"


### PR DESCRIPTION
In https://github.com/conda-forge/torchcodec-feedstock/pull/5 I added a torchcodec-tests output to the torchcodec feedstock, as originally requested in https://github.com/conda-forge/staged-recipes/pull/29447#discussion_r2019978513 .

To handle this request and possible similar modifications in the future, I think it could make sense to allow all the outputs with `torchcodec-` prefix to `torchcodec` feedstock, as anyhow the prefix is not ambigous. If instead you prefer that I explicitly list the requested outputs (now `torchcoded`, and in the future possibly more) I can listed them explicitly, thanks!

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:
* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

ping @conda-forge/torchcodec (that is actually just me)
