### PR TITLE
Add pydantic-evals.

### DIFF
--- a/requests/add-pydantic-evals.yaml
+++ b/requests/add-pydantic-evals.yaml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - pydantic_ai: pydantic-evals


### PR DESCRIPTION
ping @conda-forge/pydantic_ai 

pydantic-ai maintains another package in their [monorepo](https://github.com/pydantic/pydantic-ai), pydantic-evals. I want to add it to the feedstock outputs so we can produce a package for it, like we already do for pydantic-graph and pydantic-ai.

The approval is necessary to merge [this PR](https://github.com/conda-forge/pydantic_ai-feedstock/pull/27).