### PR TITLE
Mark all opencv-python-headless builds as broken

### DIFF
--- a/requests/opencv-python-headless-broken.yml
+++ b/requests/opencv-python-headless-broken.yml
@@ -1,0 +1,20 @@
+action: broken
+packages:
+  - linux-64/opencv-python-headless-4.11.0.86-py313h46c70d0_1.conda
+  - linux-64/opencv-python-headless-4.11.0.86-py39hf88036b_1.conda
+  - linux-64/opencv-python-headless-4.11.0.86-py311hfdbb021_1.conda
+  - osx-64/opencv-python-headless-4.11.0.86-py312haafddd8_1.conda
+  - osx-64/opencv-python-headless-4.11.0.86-py310h6954a95_1.conda
+  - osx-64/opencv-python-headless-4.11.0.86-py311hc356e98_1.conda
+  - osx-64/opencv-python-headless-4.11.0.86-py313h14b76d3_1.conda
+  - osx-64/opencv-python-headless-4.11.0.86-py39hdf37715_1.conda
+  - linux-64/opencv-python-headless-4.11.0.86-py310hf71b8c6_1.conda
+  - linux-64/opencv-python-headless-4.11.0.86-py312h2ec8cdc_1.conda
+  - osx-64/opencv-python-headless-4.11.0.86-py310h6954a95_0.conda
+  - osx-64/opencv-python-headless-4.11.0.86-py311hc356e98_0.conda
+  - osx-64/opencv-python-headless-4.11.0.86-py39hdf37715_0.conda
+  - linux-64/opencv-python-headless-4.11.0.86-py310hf71b8c6_0.conda
+  - linux-64/opencv-python-headless-4.11.0.86-py311hfdbb021_0.conda
+  - linux-64/opencv-python-headless-4.11.0.86-py312h2ec8cdc_0.conda
+  - osx-64/opencv-python-headless-4.11.0.86-py312haafddd8_0.conda
+  - linux-64/opencv-python-headless-4.11.0.86-py39hf88036b_0.conda


### PR DESCRIPTION
As discussed in https://github.com/conda-forge/opencv-python-headless-feedstock/issues/3, the `opencv-python-headless` package is a problematic package that should have not been added in conda-forge in the first place, as the same functionalities are already provided in the `py-opencv` package.

The packages maintainer and staged-recipe reviewers @nilchia and @bgruening agreed in a private mail exchange on doing this, even if it is going to break the `vtp-core` package they mantain on bioconda (see https://github.com/bioconda/bioconda-recipes/blob/e0db9267b2d8b60b377a5c2e8941f696d5090080/recipes/vpt-core/meta.yaml#L41). @hmaarrfk from @conda-forge/core was in the cc in the mail exchange.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

fyi @conda-forge/opencv @conda-forge/opencv-python-headless 