### PR TITLE
Request larger runners for ray

### DIFF
--- a/requests/ray-packages-feedstock.yaml
+++ b/requests/ray-packages-feedstock.yaml
@@ -1,0 +1,8 @@
+action: cirun
+feedstocks:
+  - ray-packages
+resources:
+  - cirun-openstack-cpu-4xlarge
+pull_request: true  
+revoke: false
+send_pr: true


### PR DESCRIPTION
The ray CI takes 5+ hours on azure devops runners, and we fairly regularly have failed runs that need to be retried due to runners getting killed (presumably OOM?)

CC: @conda-forge/ray-packages 