### PR TITLE
Request larger runners for VTK-m

### DIFF
--- a/requests/vtk-m-cirun-request.yml
+++ b/requests/vtk-m-cirun-request.yml
@@ -1,0 +1,15 @@
+action: cirun
+feedstocks:
+  # list of feedstock names (sans `-feedstock` suffix)
+  - vtk-m
+resources:
+  # list of resource names you are applying to
+  # see https://github.com/conda-forge/.cirun for available options
+  #- cirun-openstack-gpu-large
+  - cirun-openstack-cpu-2xlarge
+# switch to true if you need it on pull-requests too
+pull_request: true  
+# revoke access to the gpu runner
+revoke: false
+# Send an automatic PR to the feedstock to enable cirun defaults
+send_pr: true


### PR DESCRIPTION
## Checklist:
* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description explaining why access is needed


@conda-forge/vtk-m

VTK-m is toolkit for scientific visualization that heavily uses devices adapters such as GPUs to speedup its algorithms. VTK-m build times are very extended due to the heavy use of  metaprogramming in its source code, this is specially true when using CUDA which eventually yields builds exceeding the 6 hours max build time in conda-forge standard CI resources.

I have a PR adding CUDA to VTK-m, however, I cannot merge it since the build times sometime exceeds our 6h allocation. Having more or faster resources would alleviate this.

https://github.com/conda-forge/vtk-m-feedstock/pull/9

We need VTK-m to support CUDA in Conda since it is the only way for VTK and ParaView to support CUDA for its algorithms, since they delegate in VTK-m for GPU accelerated algorithms. This will greatly benefits the Scientific visualization community.