### PR TITLE
Add fasta2a to pydantic-ai.

### DIFF
--- a/requests/add-fasta2a.yaml
+++ b/requests/add-fasta2a.yaml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - pydantic_ai: fasta2a


### PR DESCRIPTION
ping @conda-forge/pydantic_ai

pydantic-ai maintains another package in their [monorepo](https://github.com/pydantic/pydantic-ai), fasta2a. I want to add it to the feedstock outputs so we can produce a package for it, like we already do for pydantic-graph, pydantic-ai and pydantic-evals.

The approval is necessary to merge https://github.com/conda-forge/pydantic_ai-feedstock/pull/36.