### PR TITLE
mark rattler-build 0.42.0 as broken

### DIFF
--- a/requests/rattler-build-0.42.0.yml
+++ b/requests/rattler-build-0.42.0.yml
@@ -1,0 +1,7 @@
+action: broken
+packages:
+- win-64/rattler-build-0.42.0-h63977a8_0.conda
+- linux-ppc64le/rattler-build-0.42.0-hf2b012e_0.conda
+- linux-64/rattler-build-0.42.0-h2d22210_0.conda
+- linux-aarch64/rattler-build-0.42.0-h3618846_0.conda
+- osx-arm64/rattler-build-0.42.0-h8dba533_0.conda


### PR DESCRIPTION
## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

ping @conda-forge/rattler-build 

Rattler-build 0.42.0 has a serious regression and should be pulled: https://github.com/prefix-dev/rattler-build/issues/1670
