### PR TITLE
Add pydantic-ai-slim to pydantic-ai outputs.

### DIFF
--- a/requests/add_pydantic_ai_slim.yml
+++ b/requests/add_pydantic_ai_slim.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - pydantic_ai: pydantic-ai-slim


### PR DESCRIPTION
ping @conda-forge/pydantic_ai

pydantic-ai maintains another package in their [monorepo](https://github.com/pydantic/pydantic-ai), pydantic-ai-slim. I want to add it to the feedstock outputs so we can produce a package for it, like we already do for pydantic-graph, pydantic-ai, and pydantic-evals.

The approval is necessary to merge https://github.com/conda-forge/pydantic_ai-feedstock/pull/36.