### PR TITLE
Request to archive libtiledb-sql and libtiledb-sql-py

### DIFF
--- a/requests/archive-libtiledb-sql.yml
+++ b/requests/archive-libtiledb-sql.yml
@@ -1,0 +1,4 @@
+action: archive
+feedstocks:
+  - libtiledb-sql
+  - libtiledb-sql-py


### PR DESCRIPTION
The [TileDB-MariaDB](https://github.com/TileDB-Inc/TileDB-MariaDB) software is deprecated (https://github.com/TileDB-Inc/TileDB-MariaDB/pull/390). This PR requests to archive its feedstock, [libtiledb-sql-feedstock](https://github.com/conda-forge/libtiledb-sql-feedstock), as well as the feedstock for its Python client, [libtiledb-sql-py-feedstock](https://github.com/conda-forge/libtiledb-sql-py-feedstock).

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

cc: @conda-forge/libtiledb-sql, @conda-forge/libtiledb-sql-py 
xref: https://github.com/TileDB-Inc/TileDB-MariaDB/pull/390, https://github.com/conda-forge/libtiledb-sql-feedstock/pull/203, https://github.com/conda-forge/libtiledb-sql-py-feedstock/issues/36
