### PR TITLE
Discourage the use of glob patterns when requesting additional outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,5 +79,11 @@ By default, `conda-forge` feedstocks cannot push packages to our channel that an
 when building your package indicating that the given package was not allowed for your feedstock (e.g., you moved a package
 build from one feedstock to another), you should request the output be added to the new feedstock via this repository. An example request
 is located in [examples/example-add-feedstock-output.yml](examples/example-add-feedstock-output.yml). You can add both glob patterns
-and package names. We support the glob syntax of the Python `fnmatch` module. Make a PR putting your
-`.yml` request file in the `requests` directory and the `conda-forge/core` team will review it.
+and package names.
+
+While glob patterns are support, they should be used with care as they
+essentially "squat" on all future matched. If you are requesting a specific
+package output, please use the full name of the package output. We support the
+glob syntax of the Python `fnmatch` module. Make a PR putting your `.yml`
+request file in the `requests` directory and the `conda-forge/core` team will
+review it.

--- a/examples/example-add-feedstock-output.yml
+++ b/examples/example-add-feedstock-output.yml
@@ -4,5 +4,6 @@ feedstock_to_output_mapping:
   - clang-compiler-activation: clang_impl_osx-64
   # this entry adds another output to the same feedstock
   - clang-compiler-activation: clang_impl_osx-arm64
+  # While fully specified package names are preferred, you can also use
   # this entry adds an allowed glob pattern
   - llvmdev: "libllvm*"

--- a/examples/example-add-feedstock-output.yml
+++ b/examples/example-add-feedstock-output.yml
@@ -5,5 +5,5 @@ feedstock_to_output_mapping:
   # this entry adds another output to the same feedstock
   - clang-compiler-activation: clang_impl_osx-arm64
   # While fully specified package names are preferred, you can also use
-  # this entry adds an allowed glob pattern
+  # this entry to add an allowed glob pattern
   - llvmdev: "libllvm*"


### PR DESCRIPTION
I personally think that we shouldn't use globs ever. They squat on future outputs and can have "unbound" consequences.

Instead, I want to push people to use very specific output names.

Essentially, I want to decrease my mental load when reviewing these PRs.

With the glob, it becomes a "discussion". without the glob, it is SUPER easy.