### PR TITLE
mark getopt-win32 build 2 broken

### DIFF
--- a/requests/getopt-mark-build-2-broken
+++ b/requests/getopt-mark-build-2-broken
@@ -1,0 +1,4 @@
+action: broken
+packages:
+- win-arm64/getopt-win32-0.1-hb7845dc_2.conda
+- win-64/getopt-win32-0.1-h6a83c73_2.conda

--- a/requests/getopt-mark-build-2-broken
+++ b/requests/getopt-mark-build-2-broken
@@ -1,4 +1,0 @@
-action: broken
-packages:
-- win-arm64/getopt-win32-0.1-hb7845dc_2.conda
-- win-64/getopt-win32-0.1-h6a83c73_2.conda

--- a/requests/getopt-win32-build-2-broken.yaml
+++ b/requests/getopt-win32-build-2-broken.yaml
@@ -1,0 +1,4 @@
+action: broken
+packages:
+- win-arm64/getopt-win32-0.1-hb7845dc_2.conda
+- win-64/getopt-win32-0.1-h6a83c73_2.conda


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

Build 2 of getopt-win32 didn't properly set compiler flags for exporting symbols, there was no test in the feedstock to ensure proper functioning. It is fixed in build 3 which will be made by this PR: https://github.com/conda-forge/getopt-win32-feedstock/pull/4.

Example of link-time errors using this build:
```
error LNK2019: unresolved external symbol __imp_getopt_long_a referenced in function "public: int __cdecl Coptions::parse_options(int,char * *)" (?parse_options@Coptions@@QEAAHHPEAPEAD@Z) [%SRC_DIR%\build\examples\spherical.vcxproj]
```

ping @conda-forge/getopt-win32
