### PR TITLE
Add additional output names to PyHyperScattering for optional dependencies

### DIFF
--- a/requests/add-pyhyperscattering-outputs.yml
+++ b/requests/add-pyhyperscattering-outputs.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  
+  - pyhyperscattering: pyhyperscattering-base
+  - pyhyperscattering: pyhyperscattering-gpu


### PR DESCRIPTION
Add output names `pyhyperscattering-base` and `pyhyperscattering-gpu` to `pyhyperscattering` for noarch metapackages to better cover pip extras for this package.  
* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

 ping @conda-forge/pyhyperscattering (I am the only member at present)
