### PR TITLE
Add fastapi-core output to fastapi feedstock

### DIFF
--- a/requests/add-fastapi-core-output.yml
+++ b/requests/add-fastapi-core-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+
+  - fastapi: fastapi-core


### PR DESCRIPTION
In https://github.com/conda-forge/fastapi-feedstock/pull/157 I'm adding an new output `fastapi-core` for FastAPI with no optional dependency. The current `fastapi` output is kept for backwards-compatibility, although it should have been named `fastapi-standard` because it contains the [standard](https://github.com/fastapi/fastapi/blob/cad6880fd97d6f25d3f05025c88230285386e7f9/pyproject.toml#L60-L77) dependencies.
See also https://github.com/conda-forge/fastapi-feedstock/issues/155.

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/fastapi