### PR TITLE
mark dbt-spark v1.9.2 as broken

### DIFF
--- a/requests/dbt-spark.yml
+++ b/requests/dbt-spark.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/dbt-spark-1.9.2-pyhd8ed1ab_0.conda


### PR DESCRIPTION
Package is [empty](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fnoarch%2Fdbt-spark-1.9.2-pyhd8ed1ab_0.conda) (and thus obviously [broken](https://github.com/conda-forge/dbt-spark-feedstock/pull/21)) because tag doesn't [exist](https://github.com/dbt-labs/dbt-spark/tags).

CC @conda-forge/dbt-spark 