### PR TITLE
Enable GPU runner for astra-toolbox-feedstock

### DIFF
--- a/requests/astra-toolbox-gpu-runner.yml
+++ b/requests/astra-toolbox-gpu-runner.yml
@@ -1,0 +1,14 @@
+action: cirun
+feedstocks:
+  # list of feedstock names (sans `-feedstock` suffix)
+  - astra-toolbox
+resources:
+  # list of resource names you are applying to
+  # see https://github.com/conda-forge/.cirun for available options
+  - cirun-openstack-gpu-large
+# switch to true if you need it on pull-requests too
+pull_request: true
+# revoke access to the gpu runner
+revoke: false
+# Send an automatic PR to the feedstock to enable cirun defaults
+send_pr: false

--- a/requests/astra-toolbox-gpu-runner.yml
+++ b/requests/astra-toolbox-gpu-runner.yml
@@ -11,4 +11,4 @@ pull_request: true
 # revoke access to the gpu runner
 revoke: false
 # Send an automatic PR to the feedstock to enable cirun defaults
-send_pr: false
+send_pr: true


### PR DESCRIPTION
ASTRA Toolbox is a library of GPU-accelerated tomography primitives making use of CUDA. The main functionality of the toolbox can only be tested on GPU, and we would like to enable it in the CI setup on conda-forge. The build takes ~10 min and the testing phase is ~1 min. I am the maintainer of the feedstock and I'm already added to the access list of open-gpu-server.
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->
## Checklist:

* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description explaining why access is needed

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
