### PR TITLE
Add additional outputs to robotraconteur feedstock

### DIFF
--- a/requests/robotraconteur-add-feedstock-output.yml
+++ b/requests/robotraconteur-add-feedstock-output.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - robotraconteur: robotraconteur-cpp
+  - robotraconteur: robotraconteur-python
+
+


### PR DESCRIPTION
Currently the `robotraconteur` package contain both the C++ and Python libraries. The new update will split the package into `robotraconteur-cpp` and `robotraconteur-python` with the `robotraconteur` package as a metapackage. See https://github.com/conda-forge/robotraconteur-feedstock/pull/32 for the current progress on the update. This request adds the `robotraconteur-cpp` and `robotraconteur-python` outputs.

I am the owner of the upstream project and the feedstock.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.





