### PR TITLE
Add additional outputs to robotraconteur feedstock

### DIFF
--- a/requests/robotraconteur-add-feedstock-output.yml
+++ b/requests/robotraconteur-add-feedstock-output.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - robotraconteur: librobotraconteur


### PR DESCRIPTION
After a review of #1587 by @xhochy I have renamed the C++ output package to `librobotraconteur`. This request adds the output name `librobotraconteur` to the feedstock.

I am the owner of the upstream project and the feedstock.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
