### PR TITLE
Request to add output: ufs2arco-nompi

### DIFF
--- a/requests/ufs2arco-add-feedstock-output.yml
+++ b/requests/ufs2arco-add-feedstock-output.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - ufs2arco: ufs2arco-nompi


### PR DESCRIPTION
Hello! I would like to add an optional build to the package [ufs2arco](https://anaconda.org/conda-forge/ufs2arco) which does not install mpi, so users can `conda install -c conda-forge ufs2arco-nompi`. I am very new to this, but I'm hoping this is the right way to request this additional output.

I am currently the owner/maintainer of the repo/package.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.