### PR TITLE
Add duckdb-split feedstock to duckdb-extension-ducklake output

### DIFF
--- a/requests/add-duckdb-feedstock-to-ducklake-output.yml
+++ b/requests/add-duckdb-feedstock-to-ducklake-output.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - duckdb-split: duckdb-extension-ducklake


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [ ] I want to mark a package as broken (or not broken):
  * [ ] Added a description of the problem with the package in the PR description.
  * [ ] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

We would like to build the new [DuckDB DuckLake](https://ducklake.select/) extension inside the `duckdb-split` feedstock (see https://github.com/conda-forge/duckdb-split-feedstock/pull/40).

We also build several other DuckDB extensions inside the feedstock (see [here](https://github.com/conda-forge/duckdb-split-feedstock/blob/4ddb9256e5b56ba6e203ef4cc7abcf99395e13d1/recipe/meta.yaml#L95-L249)).

Currently, we're seeing the following error in CI:

```
{
  "linux-64/duckdb-extension-json-1.3.2-hecca717_2.conda": true,
  "linux-64/duckdb-extension-tpch-1.3.2-hecca717_2.conda": true,
  "linux-64/duckdb-extension-httpfs-1.3.2-ha0421bc_2.conda": true,
  "linux-64/duckdb-extension-tpcds-1.3.2-hecca717_2.conda": true,
  "linux-64/duckdb-cli-1.3.2-hecca717_2.conda": true,
  "linux-64/duckdb-extension-fts-1.3.2-ha0421bc_2.conda": true,
  "linux-64/duckdb-extension-ducklake-1.3.2-hecca717_2.conda": false,
  "linux-64/libduckdb-1.3.2-h8eb67b4_2.conda": true,
  "linux-64/libduckdb-devel-1.3.2-hecca717_2.conda": true,
  "linux-64/duckdb-extension-autocomplete-1.3.2-hecca717_2.conda": true
}
NOTE: Any outputs marked as False are not allowed for this feedstock. See https://conda-forge.org/docs/maintainer/infrastructure/#output-validation-and-feedstock-tokens for information on how to address this error.
```

(See [here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1297880&view=logs&jobId=7b6f2c87-f3a7-5133-8d84-7c03a75d9dfc&j=7b6f2c87-f3a7-5133-8d84-7c03a75d9dfc&t=9eb77fd2-8ddd-5444-8fc0-71cb28dcb736))

We hope this admin request will resolve that error.