### PR TITLE
allow gcc-no-conda-spec output

### DIFF
--- a/requests/gcc.yaml
+++ b/requests/gcc.yaml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - ctng-compilers: gcc-no-conda-specs
+  


### PR DESCRIPTION
For https://github.com/conda-forge/ctng-compilers-feedstock/pull/180