### PR TITLE
Make the `create_feedstocks` script compatible with the PyGitHub 2.7.0 API

### DIFF
--- a/scripts/create_feedstocks.py
+++ b/scripts/create_feedstocks.py
@@ -204,11 +204,11 @@ def print_rate_limiting_info(gh, user):
     # spending it and how to better optimize it.
 
     # Get GitHub API Rate Limit usage and total
-    gh_api_remaining = gh.get_rate_limit().core.remaining
-    gh_api_total = gh.get_rate_limit().core.limit
+    gh_api_remaining = gh.get_rate_limit().resources.core.remaining
+    gh_api_total = gh.get_rate_limit().resources.core.limit
 
     # Compute time until GitHub API Rate Limit reset
-    gh_api_reset_time = gh.get_rate_limit().core.reset
+    gh_api_reset_time = gh.get_rate_limit().resources.core.reset
     gh_api_reset_time -= datetime.now(timezone.utc)
 
     print("")
@@ -229,11 +229,11 @@ def sleep_until_reset(gh):
     # sleep the job with printing every minute if we are out
     # of github api requests
 
-    gh_api_remaining = gh.get_rate_limit().core.remaining
+    gh_api_remaining = gh.get_rate_limit().resources.core.remaining
 
     if gh_api_remaining == 0:
         # Compute time until GitHub API Rate Limit reset
-        gh_api_reset_time = gh.get_rate_limit().core.reset
+        gh_api_reset_time = gh.get_rate_limit().resources.core.reset
         gh_api_reset_time -= datetime.now(timezone.utc)
 
         mins_to_sleep = int(gh_api_reset_time.total_seconds() / 60)


### PR DESCRIPTION
- The current `create_feedstocks` actions keep crashing (e.g. https://github.com/conda-forge/admin-requests/actions/runs/16696874176)
- The PyGitHub repo recently changed up their API in a backwards-incompatible way, which led to this problem
    - https://github.com/PyGithub/PyGithub/releases/tag/v2.7.0
- The `create_feedstocks` action started crashing 2 days ago, which is exactly when the v2.7.0 PyGitHub version got released.

## Other potential fixes
- `verification` does not appear in this repo, so we don't need to fix that (https://github.com/search?q=repo%3Aconda-forge%2Fadmin-requests%20verification&type=code)
- The only appearance of `get_rate_limit` in this repo is in `scripts/create_feedstocks.py`, so this is the only part of the repo that needs to be fixed (https://github.com/search?q=repo%3Aconda-forge%2Fadmin-requests%20get_rate_limit&type=code)