### PR TITLE
Add broken fancylog version

### DIFF
--- a/requests/fancylog-broken.yml
+++ b/requests/fancylog-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/fancylog-0.5.1-pyhd8ed1ab_0.conda


### PR DESCRIPTION
This PR marks version 0.5.1 of fancylog as broken due to a bug that needs fixing that causes running programs to crash. It has been [yanked on PyPI](https://pypi.org/project/fancylog/0.5.1/). I'm one of the maintainers of the package. 

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [ ] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

cc @alessandrofelder, @IgorTatarnikov
