### PR TITLE
Add hpx-system output to hpx-feedstock

### DIFF
--- a/requests/add_hpx_system.yml
+++ b/requests/add_hpx_system.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - hpx: hpx
+  - hpx: hpx-system


### PR DESCRIPTION
## Checklist:
* [X] I want to add a package output to a feedstock:
  * [X] Pinged the relevant feedstock team(s)
  * [X] Added a small description of why the output is being added.


New output is getting added: https://github.com/conda-forge/hpx-feedstock/pull/57 but build is currently failing as it is not allowed at the moment, as this is new. Hence the request.

Ping @conda-forge/hpx
