### PR TITLE
Add kikuchipy-base output to kikuchipy-feedstock

### DIFF
--- a/requests/add-kikuchipy-base.yml
+++ b/requests/add-kikuchipy-base.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - kikuchipy: kikuchipy-base


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

Currently, the [kikuchipy-feedstock](https://github.com/conda-forge/kikuchipy-feedstock) has one output with all dependencies. I'd like to add the `kikuchipy-base` output without optional dependencies.

I'm attempting to add the new output [in this PR](https://github.com/conda-forge/kikuchipy-feedstock/pull/45), which fails and prompts me to make a request here.

~I'm unsure which is the relevant feedstock team.~ There are no relevant feedstock teams.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
