### PR TITLE
Request removing accidental upload for pytorch 2.8.0

### DIFF
--- a/requests/pytorch-2-8-0.yml
+++ b/requests/pytorch-2-8-0.yml
@@ -1,0 +1,17 @@
+action: broken
+packages:
+- osx-arm64/libtorch-2.8.0-cpu_generic_h0699f12_0.conda
+- osx-arm64/libtorch-2.8.0-cpu_generic_h4194db5_0.conda
+- osx-arm64/libtorch-2.8.0-cpu_generic_h6b0ae3f_0.conda
+- osx-arm64/libtorch-2.8.0-cpu_generic_hc62c200_0.conda
+- osx-arm64/libtorch-2.8.0-cpu_generic_hd69a9e5_0.conda
+- osx-arm64/pytorch-2.8.0-cpu_generic_py39_h55530b2_0.conda
+- osx-arm64/pytorch-2.8.0-cpu_generic_py310_h20f5f40_0.conda
+- osx-arm64/pytorch-2.8.0-cpu_generic_py311_hca5bd5b_0.conda
+- osx-arm64/pytorch-2.8.0-cpu_generic_py312_hd1f36bd_0.conda
+- osx-arm64/pytorch-2.8.0-cpu_generic_py313_heefb1e6_0.conda
+- osx-arm64/pytorch-cpu-2.8.0-cpu_generic_py39_h510b526_0.conda
+- osx-arm64/pytorch-cpu-2.8.0-cpu_generic_py310_h510b526_0.conda
+- osx-arm64/pytorch-cpu-2.8.0-cpu_generic_py311_h510b526_0.conda
+- osx-arm64/pytorch-cpu-2.8.0-cpu_generic_py312_h510b526_0.conda
+- osx-arm64/pytorch-cpu-2.8.0-cpu_generic_py313_h510b526_0.conda


### PR DESCRIPTION
## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [ ] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description of why the output is being added.

-----

Accidentally pushed a branch to the wrong remote. I've removed it immediately afterwards, but I didn't notice that CI already started building `osx-arm64` packages, and they got uploaded. I'm sorry for the trouble.

Fixes conda-forge/pytorch-cpu-feedstock#410

ping @conda-forge/pytorch-cpu 