### PR TITLE
Fix improperly registered feedstock

### DIFF
--- a/requests/causal-conv1d.yml
+++ b/requests/causal-conv1d.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - causal-conv1d: causal-conv1d


### PR DESCRIPTION
For some reason, this feedstock's output did not get registered at feedstock creation time