### PR TITLE
Add yarp-rerun output in the yarp feedstock

### DIFF
--- a/requests/yarp_rerun.yaml
+++ b/requests/yarp_rerun.yaml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - yarp: "yarp-rerun"


### PR DESCRIPTION
In the latest release of YARP, support for the rerun visualizer was added, see https://github.com/conda-forge/yarp-feedstock/pull/77 . As the `librerun-sdk` dependency is not super small, I packaged it in a separate new output `yarp-rerun`.


* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

