### PR TITLE
Add xeus-octave output

### DIFF
--- a/requests/xeus-octave-output.yml
+++ b/requests/xeus-octave-output.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - xeus-octave: xeus-octave


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
    * @SylvainCorlay 
    * @AntoinePrv 
    * @rapgenic
  * [x] Added a small description of why the output is being added.
    * The package and feedstock have been renamed from `xeus_octave` to `xeus-octave`
    * Currently the package `xeus-octave` maps to the **archived** [`xeus_octave-feedstock`](https://github.com/conda-forge/xeus_octave-feedstock). The output must be updated to map to the new [`xeus-octave-feedstock`](https://github.com/conda-forge/xeus-octave-feedstock).
    * This PR is a continuation of https://github.com/conda-forge/admin-requests/pull/1628

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
