### PR TITLE
Add moor output to the moar feedstock

### DIFF
--- a/requests/moor.yaml
+++ b/requests/moor.yaml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - moar: "moor"


### PR DESCRIPTION
The `moar` package was [recently renamed to `moor`](https://github.com/walles/moor/pull/305). I've started working on a PR in the `moar` feedstock to update it, but the `moor` output is required for the CI to finish successfully.

@conda-forge/moar 

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.