### PR TITLE
archive blist

### DIFF
--- a/requests/blist.yml
+++ b/requests/blist.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - blist


### PR DESCRIPTION
I took over this feedstock many moons ago, but the upstream package stopped being updated at python 3.2(!). I had kept things compatible until 3.9, but refused to do further necromany after that. Let's pronounce this zombie dead. 😅 

Xref https://github.com/DanielStutzbach/blist/pull/97