### PR TITLE
Mark cuda build of jaxlib >= 0.6.2 as broken

### DIFF
--- a/requests/jaxlib-broken.yml
+++ b/requests/jaxlib-broken.yml
@@ -1,0 +1,13 @@
+action: broken
+packages:
+  - linux-64/jaxlib-0.7.0-cuda129py312h050a67a_200.conda
+  - linux-64/jaxlib-0.7.0-cuda129py311h4b00468_200.conda
+  - linux-64/jaxlib-0.7.0-cuda129py313h2550629_200.conda
+  - linux-64/jaxlib-0.6.2-cuda129py310hac2b8c0_201.conda
+  - linux-64/jaxlib-0.6.2-cuda129py311h4b00468_201.conda
+  - linux-64/jaxlib-0.6.2-cuda129py313h2550629_201.conda
+  - linux-64/jaxlib-0.6.2-cuda129py312h050a67a_201.conda
+  - linux-64/jaxlib-0.6.2-cuda126py310h0574136_200.conda
+  - linux-64/jaxlib-0.6.2-cuda126py312h59a9b8a_200.conda
+  - linux-64/jaxlib-0.6.2-cuda126py313hb1b46e1_200.conda
+  - linux-64/jaxlib-0.6.2-cuda126py311h88c7698_200.conda


### PR DESCRIPTION
As discussed in https://github.com/conda-forge/jaxlib-feedstock/issues/320#issuecomment-3248870416, `jaxlib` cuda builds newer then 0.6.2 create a crash on loading. 

A solution for new builds is proposed in https://github.com/conda-forge/jaxlib-feedstock/pull/322 . 

This PR proposes to mark the broken cuda packages as broken, to avoid that user accidentally install them, even if the explicitly install `jaxlib=*=*cuda*`.

>  Pinged the team for the package for their input.

@conda-forge/jax @conda-forge/jaxlib 

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.
