### PR TITLE
Unify `jupyter-ai` feedstocks

### DIFF
--- a/requests/add-feedstock-output.yml
+++ b/requests/add-feedstock-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - jupyter-ai: jupyter-ai
+  - jupyter-ai: jupyter-ai-magics

--- a/requests/archive.yml
+++ b/requests/archive.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - jupyter-ai-magics


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [ ] I want to mark a package as broken (or not broken):
  * [ ] Added a description of the problem with the package in the PR description.
  * [ ] Pinged the team for the package for their input.

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

cc @conda-forge/jupyter-ai @conda-forge/jupyter-ai-magics 

## Description

Jupyter AI is an AI extension suite for JupyterLab. Currently it consists of just 2 packages: `jupyter-ai-magics` and `jupyter-ai`. I am its lead maintainer and also maintain the corresponding feedstocks.

I recently discovered that a single recipe can output both packages even if they have dependencies on each other. I have opened a new PR in `jupyter-ai-feedstock` to output both `jupyter-ai` and `jupyter-ai-magics`: https://github.com/conda-forge/jupyter-ai-feedstock/pull/97

However, I followed the documentation and found that I need to submit this request to add `jupyter-ai-magics` as an output to `jupyter-ai-feedstock`.

I've also included a request to archive `jupyter-ai-magics-feedstock` as it will no longer be necessary. `jupyter-ai-magics` will be output from `jupyter-ai-feedstock` moving forward.

## References

- PR for multiple outputs on `jupyter-ai-feedstock`: https://github.com/conda-forge/jupyter-ai-feedstock/pull/97
- Deprecation issue on `jupyter-ai-magics-feedstock`: https://github.com/conda-forge/jupyter-ai-magics-feedstock/issues/91
