### PR TITLE
archive cykdtree and django-uuidfield

### DIFF
--- a/requests/archive-feedstocks.yml
+++ b/requests/archive-feedstocks.yml
@@ -1,0 +1,4 @@
+action: archive
+feedstocks:
+  - cykdtree  # upstream source is a 404
+  - django-uuidfield  # most recent commit upstream was 11 years ago


### PR DESCRIPTION
- cykdtree  # upstream source is a 404
- django-uuidfield  # most recent commit upstream was 11 years ago
