### PR TITLE
Archive `jasp` feedstock

### DIFF
--- a/requests/archive-jasp.yml
+++ b/requests/archive-jasp.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - jasp


### PR DESCRIPTION
The `jasp` feedstock has been unmaintained for a bit and would take significant work to rejuvenate.

https://github.com/conda-forge/jasp-feedstock/issues/26

ping @conda-forge/jasp 

## Checklist

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.
