### PR TITLE
Archive ptxcompiler

### DIFF
--- a/requests/ptxcompiler.yml
+++ b/requests/ptxcompiler.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - ptxcompiler


### PR DESCRIPTION
## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

ping @conda-forge/ptxcompiler

We are requesting to archive `ptxcompiler`.

Explanation (copied from feedstock issue):

> This package is no longer maintained, as it is designed to support only CUDA 11. CUDA 11 has been dropped from the support matrix of conda-forge and packages that were using `ptxcompiler`, including RAPIDS and numba-cuda (https://github.com/rapidsai/build-planning/issues/184).
>
> `$ mamba repoquery whoneeds -c conda-forge ptxcompiler` shows no conda-forge packages current use it.

Additional details:
- Closes https://github.com/conda-forge/ptxcompiler-feedstock/issues/43
- https://github.com/rapidsai/ptxcompiler/issues/42
