### PR TITLE
Add nlohmann_json-abi output

### DIFF
--- a/requests/example-add-feedstock-output.yml
+++ b/requests/example-add-feedstock-output.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - nlohmann_json: nlohmann_json-abi


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
    * @constantinpape
    * @SylvainCorlay
    * @JohanMabille
    * @wolfv
  * [x] Added a small description of why the output is being added.

The `nlohmann_json-abi` output will allow downstream packages to properly track ABI compatibility.
- https://github.com/conda-forge/nlohmann_json-feedstock/pull/38