### PR TITLE
Mark glfw 3.5.0 as broken

### DIFF
--- a/requests/glfw-broken.yml
+++ b/requests/glfw-broken.yml
@@ -1,0 +1,8 @@
+action: broken
+packages:
+  - osx-64/glfw-3.5.0-h1c43f85_0.conda
+  - osx-arm64/glfw-3.5.0-h6caf38d_0.conda
+  - win-64/glfw-3.5.0-hfd05255_0.conda
+  - linux-aarch64/glfw-3.5.0-he30d5cf_0.conda
+  - linux-ppc64le/glfw-3.5.0-hfc7e52b_0.conda
+  - linux-64/glfw-3.5.0-hb03c661_0.conda


### PR DESCRIPTION
See https://github.com/conda-forge/glfw-feedstock/issues/26 for the full context.

Basically, upstream glfw 3.5.0 accidentally created a 3.5.0 tag that was not a release, and we actually packaged it. However, that 3.5.0 tag has problems (see https://github.com/pygfx/pygfx/issues/1203), so we need to mark it as broken. 

Existing packages that were built against glfw 3.5.0 will not break due to https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/1083, as we were lucky enough and 3.4 and 3.5.0 basically have exactly the same public headers.

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

ping @conda-forge/glfw 

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
