### PR TITLE
archive libcal

### DIFF
--- a/requests/libcal.yml
+++ b/requests/libcal.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - libcal


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [X] I want to archive a feedstock:
  * [X] Pinged the team for that feedstock for their input.
  * [X] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [X] Linked that issue in this PR description.
  * [X] Added links to any other relevant issues/PRs in the PR description.

The issue in libcal feedstock: https://github.com/conda-forge/libcal-feedstock/issues/11

`libcal` is no longer actively maintained after checking with libcal team (same as cublasmp team). Also, the dependents (cublasmp, cusolvermp) have since dropped their dependency on `libcal` in favor of `NCCL` for a couple of releases now.

Repo query shows no other packages depend on `libcal`.

```
$ mamba repoquery whoneeds libcal -c conda-forge

Executing the query libcal

conda-forge/noarch                                  22.5MB @  40.8MB/s  0.8s
conda-forge/linux-64                                47.3MB @  48.1MB/s  1.3s


 Name           Version   Build        Depends                    Channel     Subdir
───────────────────────────────────────────────────────────────────────────────────────
 libcal-dev     0.4.3.36  h430c000_0   libcal 0.4.3.36 hee583db_0 conda-forge linux-64
 libcal-dev     0.4.3.36  h51420fd_0   conda-forge                linux-64
 libcal-dev     0.4.4.50  h418687c_2   conda-forge                linux-64
 libcal-dev     0.4.4.50  h51420fd_0   conda-forge                linux-64
 libcal-dev     0.4.4.50  h51420fd_1   conda-forge                linux-64
 libcal-dev     0.4.4.50  h74ed563_3   conda-forge                linux-64
 libcublasmp    0.2.1.427 hbc370b7_0   conda-forge                linux-64
 libcublasmp    0.2.1.427 hbc370b7_1   conda-forge                linux-64
 libcublasmp    0.2.1.427 hee583db_0   conda-forge                linux-64
 libcublasmp    0.2.1.427 hee583db_1   conda-forge                linux-64
 libcublasmp    0.3.0.620 hcd2ec93_0   conda-forge                linux-64
 libcublasmp    0.3.0.620 hcd2ec93_1   conda-forge                linux-64
 libcublasmp    0.3.1.663 hcd2ec93_0   conda-forge                linux-64
 libcublasmp    0.4.0.789 hcd2ec93_0   conda-forge                linux-64
 libcusolvermp0 0.5.1.690 h14340ca_1   conda-forge                linux-64
 libcusolvermp0 0.5.1.690 hdea8103_0   conda-forge                linux-64
 libcusolvermp0 0.6.0.712 h14340ca_0   conda-forge                linux-64
 libcusolvermp0 0.6.0.712 h14340ca_1   conda-forge                linux-64

$ mamba repoquery whoneeds libcal-dev -c conda-forge

Executing the query libcal-dev

conda-forge/linux-64                                        Using cache
conda-forge/noarch                                          Using cache


 Name       Version Build        Depends               Channel     Subdir
──────────────────────────────────────────────────────────────────────────
 cublasmp   0.2.1   hd8ed1ab_0   libcal-dev 0.4.3.36.* conda-forge noarch
 cublasmp   0.3.0   hd8ed1ab_0   conda-forge           noarch
 cublasmp   0.3.1   hd8ed1ab_0   conda-forge           noarch
 cublasmp   0.4.0   hd8ed1ab_0   conda-forge           noarch
 cusolvermp 0.5.1   hd8ed1ab_0   conda-forge           noarch
 cusolvermp 0.6.0   hd8ed1ab_0   conda-forge           noarch

```