### PR TITLE
Mark mg5amcnlo-pythia8-interface v1.3.0 build 2 as broken

### DIFF
--- a/requests/mg5amcnlo-pythia8-interface-build-2-broken.yaml
+++ b/requests/mg5amcnlo-pythia8-interface-build-2-broken.yaml
@@ -1,0 +1,6 @@
+action: broken
+packages:
+- linux-64/mg5amcnlo-pythia8-interface-1.3.0-h9e02651_2.conda
+- linux-aarch64/mg5amcnlo-pythia8-interface-1.3.0-hbd9a09b_2.conda
+- linux-ppc64le/mg5amcnlo-pythia8-interface-1.3.0-h9f0e0e5_2.conda
+- osx-arm64/mg5amcnlo-pythia8-interface-1.3.0-h382d062_2.conda


### PR DESCRIPTION
* Variants were incorrectly removed (c.f. https://github.com/conda-forge/mg5amcnlo-pythia8-interface-feedstock/pull/3) and `run_exports` from the pythia8 dependency are breaking the ability to use mg5amcnlo-pythia8-interface with pythia8 v8.311 and v8.312.
   - c.f. https://github.com/conda-forge/mg5amcnlo-pythia8-interface-feedstock/pull/4
   - c.f. [#general > Properly restirct host dependency without variants?](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/Properly.20restirct.20host.20dependency.20without.20variants.3F/with/541927665)

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input. (I am the maintainer of @conda-forge/mg5amcnlo-pythia8-interface)

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
