### PR TITLE
Add versionless output to libsdformat feedstock

### DIFF
--- a/requests/sdformat_versionless_outputs.yaml
+++ b/requests/sdformat_versionless_outputs.yaml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - libsdformat: "sdformat"
+  - libsdformat: "sdformat-python"


### PR DESCRIPTION
Leftover from https://github.com/conda-forge/admin-requests/pull/1676 . The `libsdformat` actually already existed, but `sdformat` and `sdformat-python` need to be added.

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/libsdformat 