### PR TITLE
Create tsid-broken.yml

### DIFF
--- a/requests/tsid-broken.yml
+++ b/requests/tsid-broken.yml
@@ -1,0 +1,27 @@
+action: broken
+packages:
+- osx-arm64/tsid-1.9.0-py311h13c97ad_0.conda
+- osx-64/tsid-1.9.0-py314h646b490_0.conda
+- osx-arm64/tsid-1.9.0-py314h1c9ff09_0.conda
+- osx-64/tsid-1.9.0-py311hcf07552_0.conda
+- osx-64/tsid-1.9.0-py312h160bf58_0.conda
+- osx-64/tsid-1.9.0-py310h48569be_0.conda
+- osx-arm64/tsid-1.9.0-py312hb262eaf_0.conda
+- osx-arm64/tsid-1.9.0-py313ha347755_0.conda
+- osx-arm64/tsid-1.9.0-py310h9d834e2_0.conda
+- linux-ppc64le/tsid-1.9.0-py311h7aaa9a0_0.conda
+- linux-ppc64le/tsid-1.9.0-py310h5554e13_0.conda
+- osx-64/tsid-1.9.0-py313h55395f7_0.conda
+- linux-ppc64le/tsid-1.9.0-py312h37b8ebd_0.conda
+- linux-aarch64/tsid-1.9.0-py312h228e25f_0.conda
+- linux-ppc64le/tsid-1.9.0-py313hbaa5b62_0.conda
+- linux-64/tsid-1.9.0-py314h341c59d_0.conda
+- linux-aarch64/tsid-1.9.0-py313he72ba37_0.conda
+- linux-aarch64/tsid-1.9.0-py310h9b9e361_0.conda
+- linux-aarch64/tsid-1.9.0-py311h006858d_0.conda
+- linux-64/tsid-1.9.0-py313hf05b793_0.conda
+- linux-aarch64/tsid-1.9.0-py314h94cb2a0_0.conda
+- linux-ppc64le/tsid-1.9.0-py314h08bbf7b_0.conda
+- linux-64/tsid-1.9.0-py311hd572313_0.conda
+- linux-64/tsid-1.9.0-py312hc5f9fb3_0.conda
+- linux-64/tsid-1.9.0-py310h8eaed0c_0.conda


### PR DESCRIPTION

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] ~~Pinged the team for the package for their input.~~ (I am maintainer of this feedstock)

Ping @conda-forge/tsid 

Hello,
We wanted to add a compilation flag to the TSID feedstock to enable some feature that is now almost always used by the users (see https://github.com/conda-forge/tsid-feedstock/pull/49 ).
The plan was to enable the feature before the release of 1.9.0 so that requiring version 1.9.0 or higher would always guarantee having this feature.

However, the auto-merge bot was faster than us and the release got merge before merging the feature flag in the recipe (see https://github.com/conda-forge/tsid-feedstock/pull/50 ).
Thus, the first build of TSID 1.9.0 doesn't contain this flag, but the second and all the one to come will.

In order to have something more consistent, would it be possible to remove this first build from the channel (files listed in this PR). This would ensure the flag is always on for any build/version above 1.9.0 .

Thank you
