### PR TITLE
Archive CUDA 11 infrastructure packages

### DIFF
--- a/requests/archive-cuda-11.yml
+++ b/requests/archive-cuda-11.yml
@@ -1,4 +1,5 @@
 action: archive
 feedstocks:
   - cudatoolkit
+  - cudatoolkit-dev
   - nvcc

--- a/requests/archive-cuda-11.yml
+++ b/requests/archive-cuda-11.yml
@@ -1,0 +1,4 @@
+action: archive
+feedstocks:
+  - cudatoolkit
+  - nvcc


### PR DESCRIPTION
Migrations are underway for CUDA 12.9 and CUDA 13.0:

https://conda-forge.org/status/migration/?name=cuda129
https://conda-forge.org/status/migration/?name=cuda130

An opt-in migration to keep CUDA 11.8 is available, but no updates will be provided for CUDA 11.x infrastructure.

https://conda-forge.org/status/migration/?name=cuda118

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
    * [x] @conda-forge/nvcc 
    * [x] @conda-forge/cudatoolkit 
    * [x] @conda-forge/cudatoolkit-dev 
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
    * [x] https://github.com/conda-forge/cudatoolkit-feedstock/issues/109
    * [x] https://github.com/conda-forge/nvcc-feedstock/issues/116
    * [x] https://github.com/conda-forge/cudatoolkit-dev-feedstock/issues/83
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

