### PR TITLE
Mark mg5amcnlo-pythia8-interface v1.3.0 builds 0 and 1 as broken

### DIFF
--- a/requests/mg5amcnlo-pythia8-interface-variants-not-restricted.yml
+++ b/requests/mg5amcnlo-pythia8-interface-variants-not-restricted.yml
@@ -1,0 +1,14 @@
+action: broken
+packages:
+# build numbers 0 and 1 did not have pythia8 run requirements restricted
+# to the host versions for ABI stability. Fixed in build 3.
+- linux-64/mg5amcnlo-pythia8-interface-1.3.0-h8e538f7_0.conda
+- linux-64/mg5amcnlo-pythia8-interface-1.3.0-h8f65c14_0.conda
+- linux-64/mg5amcnlo-pythia8-interface-1.3.0-h3cf2d66_1.conda
+- linux-64/mg5amcnlo-pythia8-interface-1.3.0-h48bac2b_1.conda
+- linux-aarch64/mg5amcnlo-pythia8-interface-1.3.0-h60ff9a6_1.conda
+- linux-aarch64/mg5amcnlo-pythia8-interface-1.3.0-h4860862_1.conda
+- linux-ppc64le/mg5amcnlo-pythia8-interface-1.3.0-h6e6748c_1.conda
+- linux-ppc64le/mg5amcnlo-pythia8-interface-1.3.0-hdab49dd_1.conda
+- osx-arm64/mg5amcnlo-pythia8-interface-1.3.0-hdcd1476_1.conda
+- osx-arm64/mg5amcnlo-pythia8-interface-1.3.0-h1013548_1.conda


### PR DESCRIPTION
* `mg5amcnlo-pythia8-interface` v1.3.0 build numbers 0 and 1 did not have `pythia8` run requirements restricted to the host versions for ABI stability. This can result in the wrong variant being picked up and causing a segfault at runtime. This was fixed in build number 3.
   - c.f. https://github.com/conda-forge/mg5amcnlo-pythia8-interface-feedstock/pull/4

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input. (I am the maintainer for @conda-forge/mg5amcnlo-pythia8-interface)

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
