### PR TITLE
rattler-build 0.48 is broken on osx-64

### DIFF
--- a/requests/rattler-build-48.yml
+++ b/requests/rattler-build-48.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- osx-64/rattler-build-0.48.0-h9113d71_0.conda


### PR DESCRIPTION
ref: 

- https://github.com/conda-forge/rattler-build-feedstock/issues/175
- https://github.com/prefix-dev/rattler-build/issues/1922