### PR TITLE
Add impi all-in-one package

### DIFF
--- a/requests/impi.yaml
+++ b/requests/impi.yaml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # this entry adds a package name
+  - intel_repack: impi


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

Adds a new ouptput `impi` to the `intel_repack` feedstock, @conda-forge/intel_repack 

Related to https://github.com/conda-forge/intel_repack-feedstock/pull/116

The addition has been discussed in https://github.com/conda-forge/intel_repack-feedstock/issues/58

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
