### PR TITLE
Mark virtualenv 20.35.0 as broken

### DIFF
--- a/requests/mark-virtualenv-20.35.0-broken.yml
+++ b/requests/mark-virtualenv-20.35.0-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/virtualenv-20.35.0-pyhd8ed1ab_0.conda


### PR DESCRIPTION
## Summary

This PR marks virtualenv 20.35.0 as broken on conda-forge because it has been yanked from PyPI.

## References

- Package: `noarch/virtualenv-20.35.0-pyhd8ed1ab_0.conda`
- Reason: Version yanked from PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)