### PR TITLE
Add gz collection packages output to gz-launch

### DIFF
--- a/requests/gz_distro_packages.yaml
+++ b/requests/gz_distro_packages.yaml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - gz-launch: "gz-harmonic"
+  - gz-launch: "gz-ionic"
+  - gz-launch: "gz-jetty"


### PR DESCRIPTION
In other packages managers, the Gazebo collection of libraries have named outputs to install "collection", that are collection of libraries at a given version, see:
* https://github.com/conda-forge/gz-sim-feedstock/issues/61

As `gz-launch-feedstock` is already a feedstock that depends either directly or transitively on all gz-* packages, we can reuse it also to create this collection dummy packages.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

@conda-forge/gz-launch 
