### PR TITLE
Mark gz-launch9 and libgz-launch9 packages as broken

### DIFF
--- a/requests/gz-launch9-broken.yml
+++ b/requests/gz-launch9-broken.yml
@@ -1,0 +1,10 @@
+action: broken
+packages:
+  - linux-64/gz-launch9-9.0.0-hd188261_0.conda
+  - win-64/gz-launch9-9.0.0-h4a8d78e_0.conda
+  - osx-64/gz-launch9-9.0.0-hebdadbe_0.conda
+  - osx-arm64/gz-launch9-9.0.0-h181966f_0.conda
+  - linux-64/libgz-launch9-9.0.0-hed9e494_0.conda
+  - win-64/libgz-launch9-9.0.0-h8f1ac1c_0.conda
+  - osx-64/libgz-launch9-9.0.0-h01b4ec2_0.conda
+  - osx-arm64/libgz-launch9-9.0.0-h75f3006_0.conda


### PR DESCRIPTION
As mentioned in https://github.com/conda-forge/admin-requests/pull/1676, the idea with the newer version of gz-* libraries was to switch to versionless outputs, consistently with what upstream is doing on other package managers. We did that consistently for all libraries, but we did an error for `gz-launch`. This was fixed in https://github.com/conda-forge/gz-launch-feedstock/pull/76, but to avoid confusion I think it make sense to mark `gz-launch9` and `libgz-launch9` outputs as broken to avoid confusion.

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

ping @conda-forge/gz-launch
