### PR TITLE
Upload qt-5.15 libxml2 2.14 rebuild for aarch64 and ppc64le

### DIFF
--- a/requests/qt-main-5.15-libxml2.14.yml
+++ b/requests/qt-main-5.15-libxml2.14.yml
@@ -1,7 +1,7 @@
 action: cfep3_copy
 anaconda_org_packages:
-  - package: traversaro/linux-aarch64/qt-main-5.15.15-h2f19be9_6.conda
+  - package: traversaro/label/cfep03/linux-aarch64/qt-main-5.15.15-h2f19be9_6.conda
     sha256: a91610b6df6a4a3aadfe94356a217714841829ce71b965798ae219f5687ccf46
-  - package: traversaro/linux-ppc64le/qt-main-5.15.15-h25f6ea9_6.conda
+  - package: traversaro/label/cfep03/linux-ppc64le/qt-main-5.15.15-h25f6ea9_6.conda
     sha256: 786b0d13f648c23bbc04a27e38cda844f7ae507b3b66fafb0ccc4b5f3aee955f
 to_anaconda_org_label: main


### PR DESCRIPTION
* [x] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a reference to the original PR
  * [x] Posted a link to the conda artifacts
  * [x] Posted a link to the build logs


I would like to upload the CFEP-03 builds for https://github.com/conda-forge/qt-main-feedstock/pull/356.
Artifacts:
* linux-aarch64: https://anaconda.org/traversaro/qt-main/5.15.15/download/linux-aarch64/qt-main-5.15.15-h2f19be9_6.conda
* linux-ppc64le: https://anaconda.org/traversaro/qt-main/5.15.15/download/linux-ppc64le/qt-main-5.15.15-h25f6ea9_6.conda

Logs: [qt-main-5.15.15-libxml214.zip](https://github.com/user-attachments/files/22873090/qt-main-5.15.15-libxml214.zip)

fyi @conda-forge/qt-main 