### PR TITLE
Add `ouroboros` output as alias for `ouroboros-gis`

### DIFF
--- a/requests/add-feedstock-output-ouroboros.yml
+++ b/requests/add-feedstock-output-ouroboros.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - ouroboros-gis: ouroboros


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

