### PR TITLE
Remove tsinfer 0.4.2

### DIFF
--- a/requests/tsinfer-0.4.2-broken.yml
+++ b/requests/tsinfer-0.4.2-broken.yml
@@ -1,0 +1,18 @@
+action: broken
+packages:
+  - linux-64/tsinfer-0.4.2-py310hf779ad0_0.conda
+  - linux-64/tsinfer-0.4.2-py311h0372a8f_0.conda
+  - linux-64/tsinfer-0.4.2-py312h4f23490_0.conda
+  - linux-64/tsinfer-0.4.2-py313h29aa505_0.conda
+  - osx-64/tsinfer-0.4.2-py310h0bce67a_0.conda
+  - osx-64/tsinfer-0.4.2-py311ha837bc1_0.conda
+  - osx-64/tsinfer-0.4.2-py312h391ab28_0.conda
+  - osx-64/tsinfer-0.4.2-py313h0f4b8c3_0.conda
+  - osx-arm64/tsinfer-0.4.2-py310hfdc7867_0.conda
+  - osx-arm64/tsinfer-0.4.2-py311h09efe57_0.conda
+  - osx-arm64/tsinfer-0.4.2-py312ha11c99a_0.conda
+  - osx-arm64/tsinfer-0.4.2-py313hc577518_0.conda
+  - win-64/tsinfer-0.4.2-py310h8f3aa81_0.conda
+  - win-64/tsinfer-0.4.2-py311h17033d2_0.conda
+  - win-64/tsinfer-0.4.2-py312h196c9fc_0.conda
+  - win-64/tsinfer-0.4.2-py313h0591002_0.conda


### PR DESCRIPTION
tsinfer 0.4.2 contained material changes to the algorithm that were not intended for release and were not detailed in the changelog.

* [X] I want to mark a package as broken (or not broken):
  * [X] Added a description of the problem with the package in the PR description.
  * [X] Pinged the team for the package for their input.


 ping @conda-forge/tsinfer
