### PR TITLE
Un-archive `weave` feedstock

### DIFF
--- a/requests/unarchive-weave-feedstock.yml
+++ b/requests/unarchive-weave-feedstock.yml
@@ -1,0 +1,3 @@
+action: unarchive
+feedstocks:
+  - weave


### PR DESCRIPTION
Hi, I'd like to un-archive the `weave` feedstock and make me the new maintainer.

The old project called `weave` was archived per https://github.com/conda-forge/admin-requests/pull/778.  The new project, now called `weave` on pypi, would like to start publishing on conda.
