### PR TITLE
Allow m2w64-gcc-feedstock to build m2w64-gcc package

### DIFF
--- a/requests/m2w64-gcc.yml
+++ b/requests/m2w64-gcc.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - m2w64-gcc: m2w64-gcc


### PR DESCRIPTION
## Checklist:
* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/m2w64-gcc 

Per https://github.com/conda-forge/m2w64-gcc-feedstock/pull/9

