### PR TITLE
allow libz3, z3-solver on z3prover feedstock

### DIFF
--- a/requests/z3.yml
+++ b/requests/z3.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - z3prover: libz3
+  - z3prover: z3-solver


### PR DESCRIPTION
For https://github.com/conda-forge/z3prover-feedstock/pull/10