### PR TITLE
Archive daal4py feedstock

### DIFF
--- a/requests/daal4py-archive.yml
+++ b/requests/daal4py-archive.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - daal4py


### PR DESCRIPTION
daal4py package content was merged into sklearnex in https://github.com/uxlfoundation/scikit-learn-intelex/pull/1955 (effective since [2024.7.0](https://github.com/uxlfoundation/scikit-learn-intelex/releases/tag/2024.7.0) release of sklearnex).

This change is included since 2025.0.0 version of scikit-learn-intelex-feedstock (https://github.com/conda-forge/scikit-learn-intelex-feedstock/pull/42)

Feedstock issue: https://github.com/conda-forge/daal4py-feedstock/issues/82

ping @conda-forge/daal4py

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.
