### PR TITLE
Mark `ouroboros` as broken

### DIFF
--- a/requests/ouroboros-broken.yml
+++ b/requests/ouroboros-broken.yml
@@ -1,0 +1,4 @@
+action: broken
+packages:
+- noarch/ouroboros-1.0.8-pyhd8ed1ab_2.conda
+- noarch/ouroboros-1.0.8-pyhd8ed1ab_1.conda


### PR DESCRIPTION
Trying to avoid namespace conflicts, see https://github.com/conda-forge/ouroboros-gis-feedstock/pull/10

Per @h-vetinari

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.
