### PR TITLE
Request `pytorch-cpu` access to `cirun-macos-m4-large`

### DIFF
--- a/requests/pytorch-mac.yml
+++ b/requests/pytorch-mac.yml
@@ -5,4 +5,4 @@ resources:
   - cirun-macos-m4-large
 pull_request: true
 revoke: false
-send_pr: true
+send_pr: false


### PR DESCRIPTION
## Checklist:

* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description explaining why access is needed

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

ping @conda-forge/pytorch-cpu 

xref https://github.com/conda-forge/.cirun/pull/119

The Azure CI keeps timing out, and things are getting worse from version to version. For 2.9.0, it looks unlikely that we're going to be able to manage, as the best run hasn't been even able to finish compilation, let alone start testing. See https://github.com/conda-forge/pytorch-cpu-feedstock/issues/429 and https://github.com/conda-forge/pytorch-cpu-feedstock/pull/433.