### PR TITLE
loosen assert on resource names

### DIFF
--- a/conda_forge_admin_requests/access_control.py
+++ b/conda_forge_admin_requests/access_control.py
@@ -157,8 +157,9 @@ def _process_request_for_feedstock(
 
             for resource in resources:
                 register_ci_cmd.extend(["--cirun-resources", resource])
-                assert resource.startswith("cirun-openstack"), f"Unknown resource {resource}"
+                assert resource.startswith("cirun-"), f"Unknown resource {resource}"
 
+            # this part is specific to github.com/Quansight/open-gpu-server
             if all(resource.startswith("cirun-openstack") for resource in resources):
                 for key, value in DEFAULT_CIRUN_OPENSTACK_VALUES.items():
                     for arg in value:
@@ -255,7 +256,7 @@ def check(request: Dict[str, Any]) -> None:
         resources = request["resources"]
         assert resources, "Empty resources"
         for resource in resources:
-            assert resource.startswith("cirun-openstack")
+            assert resource.startswith("cirun-")
 
     if action == "travis":
         assert not request.get("revoke", False)


### PR DESCRIPTION
Follow-up to #1743, which fails to deploy because the resource name (correctly) doesn't start with `cirun-openstack`:
```
   File "/home/runner/work/admin-requests/admin-requests/conda_forge_admin_requests/access_control.py", line 258, in check
    assert resource.startswith("cirun-openstack")
```