### PR TITLE
archive pypy3.6 feedstock

### DIFF
--- a/requests/pypy.yml
+++ b/requests/pypy.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - pypy3.6


### PR DESCRIPTION
Since https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6345, this feedstock serves no real purpose anymore, except keeping the bots busy for various migrators.

In https://github.com/conda-forge/conda-forge.github.io/issues/2255, we had discussed the possibility of building newer pypy versions so that people can `pip install` the other packages on top, but that hasn't happened either (though it could presumably, c.f. https://github.com/conda-forge/pypy3.6-feedstock/pull/121).

Still, I think it might be time to archive the feedstock; we can always un-archive it if someone's motivated to build a newer pypy.

@hmaarrfk @conda-forge/pypy3-6 