### PR TITLE
Increase runner size for onnxruntime

### DIFF
--- a/requests/onnxruntime-cirun.yml
+++ b/requests/onnxruntime-cirun.yml
@@ -2,9 +2,6 @@ action: cirun
 feedstocks:
   - onnxruntime
 resources:
-  - cirun-openstack-cpu-medium
-  - cirun-openstack-cpu-large
-  - cirun-openstack-cpu-xlarge
   - cirun-openstack-cpu-2xlarge
 pull_request: true
 revoke: false


### PR DESCRIPTION
Unfortunately, it appears that the [previously granted](https://github.com/conda-forge/admin-requests/pull/1507) runner sizes are [insufficient for onnxruntime](https://github.com/conda-forge/onnxruntime-feedstock/pull/149#issuecomment-3512456541). Hopefully one larger will do the trick. 🤞 

ping @conda-forge/onnxruntime