### PR TITLE
archive singularityce

### DIFF
--- a/requests/singularity.yml
+++ b/requests/singularity.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - singularityce


### PR DESCRIPTION
Follow-up to #1609

Apparently singularity was replaced by apptainer, but only one of the two related feedstocks was archived; see also https://github.com/conda-forge/singularity-feedstock/issues/44