### PR TITLE
mark LAPACK netlib builds `*_6` as broken on windows

### DIFF
--- a/requests/lapack.yml
+++ b/requests/lapack.yml
@@ -1,0 +1,10 @@
+action: broken
+packages:
+- win-64/blas-2.306-netlib.conda
+- win-64/blas-devel-3.11.0-6_netlib.conda
+- win-64/lapack-3.11.0-6_netlib.conda
+- win-64/libblas-3.11.0-6_h6c93730_netlib.conda
+- win-64/libcblas-3.11.0-6_hc41557d_netlib.conda
+- win-64/liblapack-3.11.0-6_h018ca30_netlib.conda
+- win-64/liblapacke-3.11.0-6_h0d55cca_netlib.conda
+- win-64/libtmglib-3.11.0-6_h018ca30_netlib.conda


### PR DESCRIPTION
The 3.11.x branch on the lapack repo was branched off main too early, causing https://github.com/conda-forge/lapack-feedstock/pull/67 to miss some relevant changes. This is being fixed in https://github.com/conda-forge/lapack-feedstock/pull/92. In the meantime, mark these builds as broken.

The builds in https://github.com/conda-forge/blas-feedstock/pull/151 should not be affected (unless someone specifically pulls in the netlib variant), but apparently user-visible breakage still occurred (see https://github.com/conda-forge/blas-feedstock/issues/155). https://github.com/conda-forge/blas-feedstock/pull/154 also shows the failures from the wrong library names.

Fixes https://github.com/conda-forge/blas-feedstock/issues/155