### PR TITLE
Mark win-64/yarp-device-realsense2-0.4.0-hca053a6_3.conda as broken

### DIFF
--- a/requests/yarp_device_realsense2.yml
+++ b/requests/yarp_device_realsense2.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- win-64/yarp-device-realsense2-0.4.0-hca053a6_3.conda


### PR DESCRIPTION
The `win-64/yarp-device-realsense2-0.4.0-hca053a6_3.conda` package is actually empty, see https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fwin-64%2Fyarp-device-realsense2-0.4.0-hca053a6_3.conda&richtable=true . So I think it make sense to mark it as broken. New (non-empty) packages are being built in https://github.com/conda-forge/yarp-device-realsense2-feedstock/pull/10 .

Together with https://github.com/conda-forge/yarp-device-realsense2-feedstock/pull/10, fix https://github.com/robotology/yarp-device-realsense2/issues/58 .

@conda-forge/yarp-device-realsense2 (that is me)

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

