### PR TITLE
zlib-ng: Add `zlib` and `libzlib` outputs, for compat

### DIFF
--- a/requests/zlib-ng-compat.yml
+++ b/requests/zlib-ng-compat.yml
@@ -3,4 +3,6 @@ feedstock_to_output_mapping:
   zlib-ng:
     - libzlib
     - zlib
+    - libzlib-wapi
+    - zlib-wapi
     - zlib-ng-compat


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

Pull request: https://github.com/conda-forge/zlib-ng-feedstock/pull/16
Discussion: https://github.com/conda-forge/conda-forge.github.io/issues/2638

ping @conda-forge/zlib-ng @conda-forge/zlib 