### PR TITLE
Mark macos alacritty builds as broken

### DIFF
--- a/requests/broken.yml
+++ b/requests/broken.yml
@@ -1,0 +1,4 @@
+action: broken
+packages:
+- osx-64/alacritty-0.16.1-hff5b9eb_1.conda
+- osx-arm64/alacritty-0.16.1-h413266f_1.conda


### PR DESCRIPTION
## Checklist:

* [x] I want to mark a package as broken:
  * [x] Added a description of the problem with the package in the PR description.
  * [ ] Pinged the team for the package for their input.

_I maintain the package, so did not ping the team._

The latest alacritty package built for macos has rendering issues (see https://github.com/conda-forge/alacritty-feedstock/issues/6#issuecomment-3574876343).

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
