### PR TITLE
Add libidyntree and idyntree-python outputs to idyntree feedstock

### DIFF
--- a/requests/idyntree_split.yaml
+++ b/requests/idyntree_split.yaml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - idyntree: "libidyntree"
+  - idyntree: "idyntree-python"


### PR DESCRIPTION
In https://github.com/conda-forge/idyntree-feedstock/pull/145 we split the monolithic `idyntree` package in C++ part (`libidyntree`) and Python part (`idyntree-python`). This reduces the time spent in CI, as the C++ part is compiled only one time for platform and not one time for each Python version.

fyi @conda-forge/idyntree (that is me)

This is similar to https://github.com/conda-forge/admin-requests/pull/1605 .

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
