### PR TITLE
Add spheno-atlas output for ATLAS experiment build variant

### DIFF
--- a/requests/add-spheno-atlas-output.yml
+++ b/requests/add-spheno-atlas-output.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - spheno: spheno-atlas


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
     - I am the @conda-forge/spheno maintainer
  * [x] Added a small description of why the output is being added.
     - In https://github.com/conda-forge/spheno-feedstock/pull/3 and https://github.com/conda-forge/spheno-feedstock/pull/4 there are patches that are needed for the ATLAS experiment that enable options that change numerical output in the tests. To confine these changes to ATLAS only, https://github.com/conda-forge/spheno-feedstock/pull/3 adds `organisation` build variants of `none` and `atlas` and https://github.com/conda-forge/spheno-feedstock/pull/5 adds a `spheno-atlas` output to the feedstock to avoid users manually requesting build variants.
     - Effective reopening of PR https://github.com/conda-forge/admin-requests/pull/1769


<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
