### PR TITLE
Request larger runners with GPU for viskores

### DIFF
--- a/requests/viskores-cirun-request.yml
+++ b/requests/viskores-cirun-request.yml
@@ -1,0 +1,14 @@
+action: cirun
+feedstocks:
+  # list of feedstock names (sans `-feedstock` suffix)
+  - viskores
+resources:
+  # list of resource names you are applying to
+  # see https://github.com/conda-forge/.cirun for available options
+  - cirun-openstack-gpu-2xlarge
+# switch to true if you need it on pull-requests too
+pull_request: true  
+# revoke access to the gpu runner
+revoke: false
+# Send an automatic PR to the feedstock to enable cirun defaults
+send_pr: true


### PR DESCRIPTION
## Checklist:
* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description explaining why access is needed


@conda-forge/viskores

Viskores (previously known as VTK-m) is a toolkit for scientific visualization that heavily uses devices adapters such as GPUs to speedup its algorithms. Viskores build times are very extended due to the heavy use of  metaprogramming in its source code, this is specially true when using CUDA which eventually yields builds exceeding the 6 hours max build time in conda-forge standard CI resources.

I have a PR adding CUDA to Viskores, however, I cannot merge it since the build times sometime exceeds our 6h allocation. Having more or faster resources would alleviate this.

https://github.com/conda-forge/viskores-feedstock/pull/6

We need Viskores to support CUDA in Conda since it is the only way for VTK and ParaView to support CUDA for its algorithms, since they delegate in Viskores for GPU accelerated algorithms. This will greatly benefits the Scientific visualization community.

The reason of requesting a GPU runner is that I we need want to smoke test the GPU backend after building.