### PR TITLE
Add new output to tomviz-feedstock

### DIFF
--- a/requests/add-tomviz-feedstock-output.yml
+++ b/requests/add-tomviz-feedstock-output.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - tomviz: tomviz-pipeline


### PR DESCRIPTION
In addition to the already existing `tomviz` output in the `tomviz-feedstock`, add `tomviz-pipeline` as a second output.

The `tomviz-pipeline` is needed for running the tomviz pipeline on headless servers, whereas the `tomviz` application itself is a GUI application.

xref: https://github.com/conda-forge/tomviz-feedstock/pull/88

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
 
ping @conda-forge/tomviz