### PR TITLE
enable cirun for openvino

### DIFF
--- a/requests/openvino.yml
+++ b/requests/openvino.yml
@@ -1,0 +1,8 @@
+action: cirun
+feedstocks:
+  - openvino
+resources:
+  - cirun-azure-windows-2xlarge
+pull_request: true  
+revoke: false
+send_pr: false


### PR DESCRIPTION
We need to run the CI registration to be able to do https://github.com/conda-forge/openvino-feedstock/pull/139

https://github.com/conda-forge/admin-requests/blob/25c13251d0643ce680ec9434ade757039cbd319e/conda_forge_admin_requests/access_control.py#L143-L207

C.f. https://github.com/conda-forge/.cirun/pull/133