### PR TITLE
redo osx runners for tensorflow

### DIFF
--- a/requests/tensorflow.yml
+++ b/requests/tensorflow.yml
@@ -1,0 +1,8 @@
+action: cirun
+feedstocks:
+  - tensorflow
+resources:
+  - cirun-macos-m4-large
+pull_request: true
+revoke: false
+send_pr: true


### PR DESCRIPTION
There still seems to be some magic sauce hidden behind the `send_pr: true` here; https://github.com/conda-forge/.cirun/pull/34 already added osx support on tensorflow long ago. On other feedstocks where we added cirun integration recently, the only thing that unblocked things (despite full config in .cirun repo) was this request _with_ `send_pr: true`.

Xref https://github.com/conda-forge/tensorflow-feedstock/pull/470, where the builds aren't starting yet