### PR TITLE
allow riscv outputs for binutils feedstock

### DIFF
--- a/requests/binutils.yml
+++ b/requests/binutils.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  binutils:
+    - binutils_impl_linux-riscv64
+    - binutils_linux-riscv64
+    - ld_impl_linux-riscv64


### PR DESCRIPTION
For https://github.com/conda-forge/binutils-feedstock/pull/106