### PR TITLE
Archive CDAT feedstocks

### DIFF
--- a/requests/archive-cdat.yml
+++ b/requests/archive-cdat.yml
@@ -1,0 +1,14 @@
+action: archive
+feedstocks:
+  - cdat_info
+  - cdms2
+  - cdp
+  - cdtime
+  - cdutil
+  - distarray
+  - ezget
+  - genutil
+  - libcdms
+  - libcf
+  - libdrs
+  - libdrs_f


### PR DESCRIPTION
Upstream maintenance ceased at the end of 2023, and conda-forge maintenance is becoming increasingly difficult as a result.

See:
https://github.com/conda-forge/cdat_info-feedstock/issues/28
https://github.com/conda-forge/cdms2-feedstock/issues/98
https://github.com/conda-forge/cdp-feedstock/issues/11
https://github.com/conda-forge/cdtime-feedstock/issues/65
https://github.com/conda-forge/cdutil-feedstock/issues/24
https://github.com/conda-forge/distarray-feedstock/issues/8
https://github.com/conda-forge/ezget-feedstock/issues/4
https://github.com/conda-forge/genutil-feedstock/issues/29
https://github.com/conda-forge/libcdms-feedstock/issues/60
https://github.com/conda-forge/libcf-feedstock/issues/56
https://github.com/conda-forge/libdrs-feedstock/issues/46
https://github.com/conda-forge/libdrs_f-feedstock/issues/30

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR, especially if:
- You want to mark packages as broken
- You want to archive a feedstock
- You want to request access to opt-in CI resources

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
ping: 
  - @conda-forge/cdat_info
  - @conda-forge/cdms2
  - @conda-forge/cdp
  - @conda-forge/cdtime
  - @conda-forge/cdutil
  - @conda-forge/distarray
  - @conda-forge/ezget
  - @conda-forge/genutil
  - @conda-forge/libcdms
  - @conda-forge/libcf
  - @conda-forge/libdrs
  - @conda-forge/libdrs_f 
