### PR TITLE
add cirun-openstack-gpu-large to tinygrad

### DIFF
--- a/requests/tinygrad.yml
+++ b/requests/tinygrad.yml
@@ -1,0 +1,8 @@
+action: cirun
+feedstocks:
+  - tinygrad
+resources:
+  - cirun-openstack-gpu-large
+pull_request: true  
+revoke: false
+send_pr: true


### PR DESCRIPTION
This is another attempt at #1818, by using one of the openstack runners (it's similarly useful to have have an actual GPU to test the JIT code there, so this makes sense independently).

That is because
https://github.com/conda-forge/admin-requests/blob/fd804c9556e60e0bb91928d07ab30d78deee5b00/conda_forge_admin_requests/access_control.py#L162-L168
does not actually work for non-openstack runners. I had not understood this aspect at the time of https://github.com/conda-forge/admin-requests/commit/da8b21ec8c3e9723ea3f39e15c2a88e718882e44, apologies.

This is not easy to extend because the interface in smithy [expects](https://github.com/conda-forge/conda-smithy/blob/e0c56f673aaebc2805fa0a4679db56d00d105c81/conda_smithy/cirun_utils.py#L75) `--cirun_users_from_json=...` as an argument, which is not necessarily what we want for other resources (where a simple `users:` list should be created). We'll probably have to expand that interface (both in the yamls here, as well as in smithy; cirun itself [should](https://github.com/AktechLabs/cirun-py/blob/ad333b84f0b663fe007ad15002ecdac5c492d745/cirun/client.py#L137) be generic enough AFAICT).

Concretely, after #1818 there was a [PR](https://github.com/conda-forge/tinygrad-feedstock/pull/11) to the feedstock (though not to `.cirun`, which I handled in https://github.com/conda-forge/.cirun/pull/138), but it did not set up any actions.

This is yet another aspect of #1749