### PR TITLE
Add output python-neo-lzf to python-lzf feedstock

### DIFF
--- a/requests/add-output-python-neo-lzf.yml
+++ b/requests/add-output-python-neo-lzf.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  python-lzf:
+    - python-neo-lzf


### PR DESCRIPTION
I maintain [conda-forge/python-lzf-feedstock](https://github.com/conda-forge/python-lzf-feedstock). I want to build the package based on a fork ([python-neo-lzf](https://github.com/FledgeXu/python-neo-lzf)) that has been picked up by a [package](https://github.com/MapIV/pypcd4) that previously depended on python-lzf. The [python-lzf upstream](https://github.com/teepark/python-lzf) has been abandoned for a long time.

I want to to transition python-lzf-feedstock to a split package that provides python-neo-lzf, and the alias python-lzf.

If users require the old upstream they can pin the package to `0.2.6`.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
