### PR TITLE
Add requests-ntlm output to requests_ntlm feedstock

### DIFF
--- a/requests/add-requests_ntlm-outputs.yml
+++ b/requests/add-requests_ntlm-outputs.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  requests_ntlm: requests-ntlm


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/requests_ntlm 

This is following up the suggestion made in https://github.com/regro/cf-scripts/issues/5250#issuecomment-3665727176 and discussed in https://github.com/conda-forge/requests_ntlm-feedstock/issues/6