### PR TITLE
Add libmamba-spdlog output to mamba feedstock

### DIFF
--- a/requests/add_mamba_spdlog_output.yml
+++ b/requests/add_mamba_spdlog_output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  mamba:
+    - libmamba-spdlog


### PR DESCRIPTION
https://github.com/mamba-org/mamba/pull/4082 removed spdlog from libmamba so that the user can specify a different logging system. This also makes libmamba easier to maintain regarding concurrency and initialization.

spdlog is still provided as the default logger, but in a separate library now.

This PR has been merged and will be part of [2.5.0](https://github.com/conda-forge/mamba-feedstock/pull/374), thus this admin request.