### PR TITLE
archive torch-scatter

### DIFF
--- a/requests/torch-scatter.yml
+++ b/requests/torch-scatter.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - torch-scatter


### PR DESCRIPTION
Redundant with `pytorch_scatter` and less used, see https://github.com/conda-forge/torch-scatter-feedstock/issues/43