### PR TITLE
improve error when passing string instead of list for add_output

### DIFF
--- a/requests/fail.yml
+++ b/requests/fail.yml
@@ -1,3 +1,0 @@
-action: add_feedstock_output
-feedstock_to_output_mapping:
-  requests_ntlm: requests-ntlm


### PR DESCRIPTION
follow-up to #1828; alternative to #1829 (which I just saw now after writing this)

CC @beckermr