### PR TITLE
Add fastlowess outputs (libfastlowess, r-rfastlowess)

### DIFF
--- a/requests/add-fastlowess-outputs.yml
+++ b/requests/add-fastlowess-outputs.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  fastlowess:
+    - libfastlowess
+    - r-rfastlowess


### PR DESCRIPTION
## Adding Package Outputs to fastlowess Feedstock

I'm adding new multi-output packages to the `fastlowess-feedstock`:

- **`libfastlowess`** - C++ library bindings for the fastlowess library
- **`r-rfastlowess`** - R package bindings for the fastlowess library

These outputs are produced by the same feedstock recipe but were not registered when the feedstock was initially created.

cc @conda-forge/fastlowess

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.