### PR TITLE
Add libcompiler-rt output

### DIFF
--- a/requests/compiler-rt.yml
+++ b/requests/compiler-rt.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  compiler-rt:
+    - libcompiler-rt


### PR DESCRIPTION
* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
  
See https://github.com/conda-forge/compiler-rt-feedstock/pull/168
cc @conda-forge/compiler-rt 
<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
