### PR TITLE
allow building llvmdev & clangdev on cirun

### DIFF
--- a/requests/llvm.yml
+++ b/requests/llvm.yml
@@ -1,0 +1,9 @@
+action: cirun
+feedstocks:
+  - llvmdev
+  - clangdev
+resources:
+  - cirun-azure-windows-2xlarge
+pull_request: true  
+revoke: false
+send_pr: true


### PR DESCRIPTION
Builds of `llvmdev` on windows have been timing out more and more with each release, and as of v22 it seems this will be a real pain. The situation for `clangdev` is similar, though slightly less urgent. Allow using the smalles available windows agents from https://github.com/conda-forge/.cirun/blob/main/.access.yml instead, so we don't run into the hard 6h cut-off on AZP.