### PR TITLE
Add `libpython` output to `python`

### DIFF
--- a/requests/python-libpython.yml
+++ b/requests/python-libpython.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  python:
+    - libpython


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

Per https://github.com/conda-forge/python-feedstock/issues/843.

ping @conda-forge/python 