### PR TITLE
Add fastlowess outputs (libfastlowess, r-rfastlowess)

### DIFF
--- a/requests/add-fastlowess-outputs.yml
+++ b/requests/add-fastlowess-outputs.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  fastlowess:
+    - libfastlowess
+    - r-rfastlowess


### PR DESCRIPTION
## Adding Package Outputs to fastlowess Feedstock
I'm adding new multi-output packages to the fastlowess-feedstock:
- **libfastlowess** (C++ shared library)
- **r-rfastlowess** (R bindings)
These outputs were added to the recipe but failed validation because they weren't in the allowed outputs list.
cc @conda-forge/fastlowess


## Checklist:

* [ ] I want to mark a package as broken (or not broken):
  * [ ] Added a description of the problem with the package in the PR description.
  * [ ] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

