### PR TITLE
Add human-readable output to human_readable

### DIFF
--- a/requests/human_readable.yml
+++ b/requests/human_readable.yml
@@ -1,5 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
   human_readable:
-    - human_readable
     - human-readable


### PR DESCRIPTION
Adding an alias so users can use the same package name as on PyPI

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
