### PR TITLE
Mark  linux-64/libgz-common-7.0.0-h45aaabd_4.conda as broken

### DIFF
--- a/requests/gz_common_missing_assimp.yml
+++ b/requests/gz_common_missing_assimp.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- linux-64/libgz-common-7.0.0-h45aaabd_4.conda


### PR DESCRIPTION
As discussed in https://github.com/conda-forge/gz-sim-feedstock/issues/130#issuecomment-3805566237, the `linux-64/libgz-common-7.0.0-h45aaabd_4.conda` seems somehow malformed, as the `assimp` package dependency is missing, even if it was present in the `run_exports` of a host dependency.

As it is not clear what went wrong there, and a build of libgz-common 7.* with assimp 6 is available with the 7.0.1 build, I think the safest option is just to mark the package as broken.

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

