### PR TITLE
Mark numba-cuda 0.26.0 build 0 broken

### DIFF
--- a/requests/numba_cuda_broken_pinning.yml
+++ b/requests/numba_cuda_broken_pinning.yml
@@ -1,0 +1,17 @@
+action: broken
+packages:
+- linux-64/numba-cuda-0.26.0-py310h44b86e0_0.conda
+- linux-64/numba-cuda-0.26.0-py311hf51f001_0.conda
+- linux-64/numba-cuda-0.26.0-py312h14c7f5c_0.conda
+- linux-64/numba-cuda-0.26.0-py313h92f78c6_0.conda
+- linux-64/numba-cuda-0.26.0-py314h118ebf0_0.conda
+- linux-aarch64/numba-cuda-0.26.0-py310h4c49e2c_0.conda
+- linux-aarch64/numba-cuda-0.26.0-py311h3512406_0.conda
+- linux-aarch64/numba-cuda-0.26.0-py312h62ce522_0.conda
+- linux-aarch64/numba-cuda-0.26.0-py313h2936e36_0.conda
+- linux-aarch64/numba-cuda-0.26.0-py314h7b1796c_0.conda
+- win-64/numba-cuda-0.26.0-py310h0cfeda3_0.conda
+- win-64/numba-cuda-0.26.0-py311h77e552c_0.conda
+- win-64/numba-cuda-0.26.0-py312hf4e254d_0.conda
+- win-64/numba-cuda-0.26.0-py313h3db9a1b_0.conda
+- win-64/numba-cuda-0.26.0-py314h1d649d3_0.conda


### PR DESCRIPTION
The `numba-cuda==0.26.0` build `0` had an incorrect pinning to `cuda-core>=0.3.2` where the correct one should have been `cuda-core>=0.5.1` and has since been corrected in https://github.com/conda-forge/numba-cuda-feedstock/pull/80. Now build `0` has to be marked broken so it's not anymore incorrectly installable.

cc @conda-forge/cuda-python 

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.