### PR TITLE
Add `rust-docs` as output for `rust` feedstock

### DIFF
--- a/requests/add-rust-docs.yml
+++ b/requests/add-rust-docs.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  rust:
+    - rust-docs


### PR DESCRIPTION

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

In [this PR](https://github.com/conda-forge/rust-feedstock/pull/268) Im splitting the rust documentation into its own package, out of the rust compiler package.
