### PR TITLE
Upload qt-5.15 libxml2 icu 78 rebuild for aarch64

### DIFF
--- a/requests/qt-main-5.15-icu78.yml
+++ b/requests/qt-main-5.15-icu78.yml
@@ -1,5 +1,5 @@
 action: cfep3_copy
 anaconda_org_packages:
-  - package: TobiasRobotics/qt-main/5.15.15/linux-aarch64/qt-main-5.15.15-h912a755_7.conda
+  - package: tobiasrobotics/linux-aarch64/qt-main-5.15.15-h912a755_7.conda
     sha256: 279ed48d551966178cfde61d84c1b6ea9f2c0ad68620eb61f8ab8dff62a813d4
 to_anaconda_org_label: main


### PR DESCRIPTION
## Checklist:

* [x] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a reference to the original PR
  * [x] Posted a link to the conda artifacts
  * [x] Posted a link to the build logs

I would like to upload the CFEP-03 builds for https://github.com/conda-forge/qt-main-feedstock/pull/380.
Artifacts:
* linux-aarch64: https://anaconda.org/tobiasrobotics/linux-aarch64/qt-main-5.15.15-h912a755_7.conda

Logs: [log_qt_main.txt](https://github.com/user-attachments/files/25026877/log_qt_main.txt)

@conda-forge/qt-main 