### PR TITLE
Add cutile-python output to cutile-python feedstock

### DIFF
--- a/requests/cutile-python.yml
+++ b/requests/cutile-python.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  cutile-python:
+    - cutile-python


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

The `cutile-python` feedstock is brand new, and it was created without any outputs (staged-recipes could not build its packages due to CUDA 13.1 requirements). I am working on the feedstock now to add the primary output, `cutile-python`.

  ping @conda-forge/cutile-python (currently that team is just me, I am updating this in https://github.com/conda-forge/cutile-python-feedstock/pull/2)

Resolves errors like:

```
validation results:
{
  "linux-64/cutile-python-1.1.0-py310h44b86e0_0.conda": false
}
NOTE: Any outputs marked as False are not allowed for this feedstock. See https://conda-forge.org/docs/maintainer/infrastructure/#output-validation-and-feedstock-tokens for information on how to address this error.
```