### PR TITLE
archive one-off branch for ancient version on openssl feedstock

### DIFF
--- a/requests/openssl.yml
+++ b/requests/openssl.yml
@@ -1,0 +1,4 @@
+action: archive_branch
+feedstocks:
+  openssl:
+    - 1.1.1a


### PR DESCRIPTION
This was only ever used for https://github.com/conda-forge/openssl-feedstock/pull/42; the 1.1.1 branch continued for a long time after that. I'm not archiving that (and the other already EOL 1.0.2 and 3.1 branches) due to the central role of openssl, where I don't want to cause even a hint of doubt