### PR TITLE
Add root_cxx_standard output to root feedstock

### DIFF
--- a/requests/root-cxx-standard.yml
+++ b/requests/root-cxx-standard.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  root:
+    - root_cxx_standard


### PR DESCRIPTION
## Summary
- Register `root_cxx_standard` as an allowed output for the `root` feedstock
- Fixes output validation failure for `noarch/root_cxx_standard-20-20.conda`