### PR TITLE
Add eigen-abi and eigen-abi-devel outputs to eigen feedstock

### DIFF
--- a/requests/eigen_abi.yaml
+++ b/requests/eigen_abi.yaml
@@ -1,4 +1,5 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
-  - eigen: "eigen-abi"
-  - eigen: "eigen-abi-devel"
+  eigen:
+    - eigen-abi
+    - eigen-abi-devel


### PR DESCRIPTION
`eigen` is a bit of strange case, as it is an header-only library that is commonly use in the public API (and ABI) of compiled libraries, see . 

To deal with this situation, in https://github.com/conda-forge/eigen-feedstock/pull/49 it was decided to add the `eigen-abi` and `eigen-abi-devel` outputs to the feedstock. This PR is required to unblock https://github.com/conda-forge/eigen-feedstock/pull/49  .

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

@conda-forge/eigen
