### PR TITLE
Add lumen-ai output for lumen-feedstock

### DIFF
--- a/requests/lumen-add-ai-output.yml
+++ b/requests/lumen-add-ai-output.yml
@@ -1,0 +1,8 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  lumen:
+    - lumen-ai
+    - lumen-ai-local
+    - lumen-ai-openai
+    - lumen-ai-mistralai
+    - lumen-ai-anthropic


### PR DESCRIPTION
Adding new AI-related outputs to the `lumen-feedstock` to align with Anaconda's recipes which already has multiple outputs. See [conda-forge/lumen-feedstock#18](https://github.com/conda-forge/lumen-feedstock/pull/18) for the feedstock PR.

New outputs: `lumen-ai`, `lumen-ai-local`, `lumen-ai-openai`, `lumen-ai-mistralai`, `lumen-ai-anthropic`

@conda-forge/lumen

## Checklist:
* [x] I want to add a package output to a feedstock:
* [x] Pinged the relevant feedstock team(s)
* [x] Added a small description of why the output is being added.