### PR TITLE
Mark TSAM 3.0.0 and 3.1.0 as broken

### DIFF
--- a/requests/reskit-broken.yml
+++ b/requests/reskit-broken.yml
@@ -1,3 +1,4 @@
 action: broken
 packages:
-  - noarch/reskit-0.3.0-pyhd8ed1ab_0.tar.bz2
+- noarch/tsam-3.1.0-pyhd8ed1ab_0.conda
+- noarch/tsam-3.0.0-pyhd8ed1ab_0.conda


### PR DESCRIPTION

Hi,

Versions 3.0.0 and 3.1.0 of TSAM contain various bugs and lack important features from version 2.x. These bugs have been fixed and the missing features have been added in version 3.1.1, which is documented here: https://github.com/FZJ-IEK3-VSA/tsam/releases/tag/v3.1.1. I want to remove these versions, which have already been removed from PYPI: https://pypi.org/project/tsam/#history.

For the record, I can ping @conda-forge/tsam , but I am the only active maintainer.



## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

* [ ] I want to archive a feedstock:
  * [ ] Pinged the team for that feedstock for their input.
  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [ ] Linked that issue in this PR description.
  * [ ] Added links to any other relevant issues/PRs in the PR description.

* [ ] I want to request (or revoke) access to an opt-in CI resource:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a reference to the original PR
  * [ ] Posted a link to the conda artifacts
  * [ ] Posted a link to the build logs

* [ ] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description of why the output is being added.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
