### PR TITLE
archive qt6 branches for qt-main/pyqt after merges back to main

### DIFF
--- a/requests/qt.yml
+++ b/requests/qt.yml
@@ -1,0 +1,6 @@
+action: archive_branch
+feedstocks:
+  qt-main:
+    - qt6
+  pyqt:
+    - qt6


### PR DESCRIPTION
The qt6 transition has been particular because there were long-lived special branches for qt6 while `main` stayed on qt5. Recently, qt6 has become `main` in the following two PRs:
* https://github.com/conda-forge/qt-main-feedstock/pull/350
* https://github.com/conda-forge/pyqt-feedstock/pull/162

This means that the old qt6 branches are now either abandoned (i.e. falling behind main, see [here](https://github.com/conda-forge/qt-main-feedstock/tree/qt6)), or show a deletion dialogue that might be tempting for a maintainer or core member who comes along

<img width="1162" height="165" alt="image" src="https://github.com/user-attachments/assets/8550de02-b4d7-4a49-a4bd-2a7c8efed3f6" />

The recently-introduce capability to "archive" branches (by turning them into git tags; [details](https://github.com/conda-forge/conda-forge.github.io/issues/1972); sample [result](https://github.com/conda-forge/arrow-cpp-feedstock/tags) from #1883) would be useful here, because it would allow us to reflect the reality that this branch was an essential part of the feedstock for years, while getting it out of the way of ongoing operations. Not that I expect us to need it, but this operation can also be reversed where necessary.

CC @conda-forge/qt-main @conda-forge/pyqt