### PR TITLE
Request mujoco-sysid output for mujoco feedstock

### DIFF
--- a/requests/mujoco-sysid.yml
+++ b/requests/mujoco-sysid.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  mujoco:
+    - mujoco-sysid


### PR DESCRIPTION
This PR requests adding the mujoco-sysid output to the mujoco feedstock allowlist.

Related: https://github.com/conda-forge/mujoco-feedstock/pull/115
