### PR TITLE
Request Windows cirun runner for llama.cpp

### DIFF
--- a/requests/llamacpp.yml
+++ b/requests/llamacpp.yml
@@ -3,6 +3,6 @@ feedstocks:
   - llama.cpp
 resources:
   - cirun-azure-windows-2xlarge
-pull_request: true  
+pull_request: true
 revoke: false
 send_pr: true


### PR DESCRIPTION
Windows CUDA jobs are taking more then 6h, see https://github.com/conda-forge/llama.cpp-feedstock/pull/92 . 

I think it would be great if we could use more powerful machines for the Windows build of llama.cpp . fyi @wolfv @baszalmstra

@conda-forge/llama-cpp 

## Checklist:

* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description explaining why access is needed

