### PR TITLE
Add split pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,66 +1,9 @@
-<!--
-Hi!
+## Template selection
 
-Thank you for making an admin request on this repo. We strive to make a decision
-on these requests within 24 hours.
+Please go to the "Preview" tab and select the appropriate template:
 
-Please use the text below to add context about this PR, especially if:
-- You want to mark packages as broken
-- You want to archive a feedstock
-- You want to request access to opt-in CI resources
-
-Cheers and thank you for contributing to conda-forge!
--->
-
-## Guidelines for marking packages as broken:
-
-* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
-  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
-* Packages with requirements/metadata that are too strict but otherwise work are
-  not technically broken and should not be marked as such.
-* Packages with missing metadata can be marked as broken on a temporary basis
-  but should be patched in the repo data and be marked unbroken later.
-* In some cases where the number of users of a package is small or it is used by
-  the maintainers only, we can allow packages to be marked broken more liberally.
-* You can use `pixi run find-name {matchspec}` to get a list of filenames matching given spec.
-* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.
-
-What will happen when a package is marked broken?
-
-* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
-* Our bots will rebuild our repodata patches to remove this package from the repodata.
-* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.
-
-
-## Checklist:
-
-* [ ] I want to mark a package as broken (or not broken):
-  * [ ] Added a description of the problem with the package in the PR description.
-  * [ ] Pinged the team for the package for their input.
-
-* [ ] I want to archive a feedstock:
-  * [ ] Pinged the team for that feedstock for their input.
-  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
-  * [ ] Linked that issue in this PR description.
-  * [ ] Added links to any other relevant issues/PRs in the PR description.
-
-* [ ] I want to request (or revoke) access to an opt-in CI resource:
-  * [ ] Pinged the relevant feedstock team(s)
-  * [ ] Added a small description explaining why access is needed
-
-* [ ] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
-  * [ ] Pinged the relevant feedstock team(s)
-  * [ ] Added a reference to the original PR
-  * [ ] Posted a link to the conda artifacts
-  * [ ] Posted a link to the build logs
-
-* [ ] I want to add a package output to a feedstock:
-  * [ ] Pinged the relevant feedstock team(s)
-  * [ ] Added a small description of why the output is being added.
-
-<!--
-For example if you are trying to mark a `foo` conda package as broken.
-
-  ping @conda-forge/foo
-
--->
+* [I want to mark a package as broken (or not broken)](?expand=1&template=broken.md)
+* [I want to archive a feedstock](?expand=1&template=archive.md)
+* [I want to request (or revoke) access to an opt-in CI resource](?expand=1&template=ci-resource.md)
+* [I want to copy an artifact following CFEP-3](?expand=1&template=cfep-3.md)
+* [I want to add a package output to a feedstock](?expand=1&template=add-feedstock-output.md)

--- a/.github/PULL_REQUEST_TEMPLATE/add-feedstock-output.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add-feedstock-output.md
@@ -1,0 +1,23 @@
+<!--
+Hi!
+
+Thank you for making an admin request on this repo. We strive to make a decision
+on these requests within 24 hours.
+
+Please use the text below to add context about this PR.
+
+Cheers and thank you for contributing to conda-forge!
+-->
+
+## Checklist:
+
+* [x] I want to add a package output to a feedstock:
+  * [ ] Pinged the relevant feedstock team(s)
+  * [ ] Added a small description of why the output is being added.
+
+<!--
+For example if you are trying to add an output to 'foo' feedstock.
+
+  ping @conda-forge/foo
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/archive.md
+++ b/.github/PULL_REQUEST_TEMPLATE/archive.md
@@ -1,0 +1,25 @@
+<!--
+Hi!
+
+Thank you for making an admin request on this repo. We strive to make a decision
+on these requests within 24 hours.
+
+Please use the text below to add context about this PR.
+
+Cheers and thank you for contributing to conda-forge!
+-->
+
+## Checklist:
+
+* [x] I want to archive a feedstock:
+  * [ ] Pinged the team for that feedstock for their input.
+  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
+  * [ ] Linked that issue in this PR description.
+  * [ ] Added links to any other relevant issues/PRs in the PR description.
+
+<!--
+For example if you are trying to archive a `foo` feedstock.
+
+  ping @conda-forge/foo
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/broken.md
+++ b/.github/PULL_REQUEST_TEMPLATE/broken.md
@@ -1,0 +1,43 @@
+<!--
+Hi!
+
+Thank you for making an admin request on this repo. We strive to make a decision
+on these requests within 24 hours.
+
+Please use the text below to add context about this PR.
+
+Cheers and thank you for contributing to conda-forge!
+-->
+
+## Guidelines for marking packages as broken:
+
+* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
+  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
+* Packages with requirements/metadata that are too strict but otherwise work are
+  not technically broken and should not be marked as such.
+* Packages with missing metadata can be marked as broken on a temporary basis
+  but should be patched in the repo data and be marked unbroken later.
+* In some cases where the number of users of a package is small or it is used by
+  the maintainers only, we can allow packages to be marked broken more liberally.
+* You can use `pixi run find-name {matchspec}` to get a list of filenames matching given spec.
+* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.
+
+What will happen when a package is marked broken?
+
+* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
+* Our bots will rebuild our repodata patches to remove this package from the repodata.
+* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.
+
+
+## Checklist:
+
+* [x] I want to mark a package as broken (or not broken):
+  * [ ] Added a description of the problem with the package in the PR description.
+  * [ ] Pinged the team for the package for their input.
+
+<!--
+For example if you are trying to mark a `foo` conda package as broken.
+
+  ping @conda-forge/foo
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/cfep-3.md
+++ b/.github/PULL_REQUEST_TEMPLATE/cfep-3.md
@@ -1,0 +1,25 @@
+<!--
+Hi!
+
+Thank you for making an admin request on this repo. We strive to make a decision
+on these requests within 24 hours.
+
+Please use the text below to add context about this PR.
+
+Cheers and thank you for contributing to conda-forge!
+-->
+
+## Checklist:
+
+* [x] I want to copy an artifact following [CFEP-3](https://github.com/conda-forge/cfep/blob/main/cfep-03.md):
+  * [ ] Pinged the relevant feedstock team(s)
+  * [ ] Added a reference to the original PR
+  * [ ] Posted a link to the conda artifacts
+  * [ ] Posted a link to the build logs
+
+<!--
+For example if you are trying to copy artifacts for `foo` feedstock.
+
+  ping @conda-forge/foo
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/ci-resource.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ci-resource.md
@@ -1,0 +1,23 @@
+<!--
+Hi!
+
+Thank you for making an admin request on this repo. We strive to make a decision
+on these requests within 24 hours.
+
+Please use the text below to add context about this PR.
+
+Cheers and thank you for contributing to conda-forge!
+-->
+
+## Checklist:
+
+* [x] I want to request (or revoke) access to an opt-in CI resource:
+  * [ ] Pinged the relevant feedstock team(s)
+  * [ ] Added a small description explaining why access is needed
+
+<!--
+For example if you are trying to request access for the `foo` feedstock.
+
+  ping @conda-forge/foo
+
+-->


### PR DESCRIPTION
Add split templates for all the five paths our pull requests take.  This makes it possible to use a parameter such as `?template=archive.md` to display a more specific template than the base one (which remains the default).  These templates can be used in the future to facilitate easier pull request workflows.

Initially, the text is mostly unchanged from the base template, except where the information was irrelevant.

Bug #535

CC @jaimergp 