### PR TITLE
Copy missing "broken" instructions from conda-forge.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Guidelines for marking packages as broken:
   but should be patched in the repo data and be marked unbroken later.
 * In some cases where the number of users of a package is small or it is used by
   the maintainers only, we can allow packages to be marked broken more liberally.
+* The paths to broken files can be located on [anaconda.org](https://anaconda.org/),
+  by searching for the conda-forge package and switching to the files tab.
 * We (`conda-forge/core`) try to make a decision on these requests within 24 hours.
 
 


### PR DESCRIPTION
Since we want to keep the instructions in one place, https://github.com/conda-forge/conda-forge.github.io/pull/2764 proposes to replace the existing instructions on conda-forge.org with a link to this README file. Copy the missing bits from that document here, so we don't lose them.

CC @jaimergp 