### PR TITLE
Ignore Pixi related outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ cython_debug/
 #.idea/
 
 .DS_Store
+
+# Pixi
+pixi.lock
+.pixi/


### PR DESCRIPTION
With https://github.com/conda-forge/admin-requests/pull/1922, there are pixi tasks in this repo, which means that Pixi will lock and create envs. We don't want those files accidentally committed, so let's ignore them!