### PR TITLE
Add fastjet-cxx-devel output to seperate development components

### DIFF
--- a/requests/add-fastjet-cxx-devel-output.yml
+++ b/requests/add-fastjet-cxx-devel-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  fastjet-cxx:
+    - fastjet-cxx-devel


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
      - I am a maintainer of @conda-forge/fastjet-cxx 
  * [x] Added a small description of why the output is being added.
      - Needed for https://github.com/conda-forge/fastjet-cxx-feedstock/pull/27 which splits the feedstock into runtime and development package components. cc @chrisburr 

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
