### PR TITLE
Add feedstock output mapping for bfee2 to bfee3

### DIFF
--- a/requests/add-bfee2-output-bfee3.yaml
+++ b/requests/add-bfee2-output-bfee3.yaml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+
+feedstock_to_output_mapping:
+  bfee2:
+    - bfee3


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

Pinged relevant feedstock team: @conda-forge/bfee2

This PR requests adding `bfee3` as an allowed output for `bfee2-feedstock`.

`bfee3` is being added as an alias package for `bfee2` to preserve compatibility for users who still install the old package name.