### PR TITLE
Add new outputs added in lerobot 0.5.0 release

### DIFF
--- a/requests/lerobot-0-5-0.yml
+++ b/requests/lerobot-0-5-0.yml
@@ -1,0 +1,7 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  lerobot:
+    - lerobot-scipy-dep
+    - lerobot-pi
+    - lerobot-matplotlib-dep
+    - lerobot-peft-dep


### PR DESCRIPTION
This PR requests adding the lerobot-scipy-dep, lerobot-pi, lerobot-matplotlib-dep and lerobot-peft-dep outputs to the lerobot feedstock allowlist, as they were added in lerobot 0.5.0 . 

Related: https://github.com/conda-forge/lerobot-feedstock/pull/8

fyi @conda-forge/lerobot

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
