### PR TITLE
add formulas output formulas-cli

### DIFF
--- a/requests/add-formulas-output-formulas-cli.yml
+++ b/requests/add-formulas-output-formulas-cli.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  formulas:
+    - formulas-cli


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.


ping @conda-forge/formulas


This adds `formulas-cli` to `formulas`, unblocking https://github.com/conda-forge/formulas-feedstock/pull/21