### PR TITLE
Add `libblpapi-devel` and `libblpapi` output to blpapi feedstock

### DIFF
--- a/requests/add-blpapi-output-blpapi-cpp.yml
+++ b/requests/add-blpapi-output-blpapi-cpp.yml
@@ -1,4 +1,5 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
   blpapi:
-    - blpapi-cpp
+    - libblpapi-devel
+    - libblpapi


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

@conda-forge/blpapi

Adding `libblpapi-devel` and `libblpapi` as allowed outputs of the `blpapi` feedstock. This PR is what makes this change: https://github.com/conda-forge/blpapi-feedstock/pull/65

🤖 Generated with [Claude Code](https://claude.com/claude-code)