### PR TITLE
add py-maidr output-py-maidr-with-plotly

### DIFF
--- a/requests/add-py-maidr-output-py-maidr-with-plotly.yml
+++ b/requests/add-py-maidr-output-py-maidr-with-plotly.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  py-maidr:
+    - py-maidr-with-plotly


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

:bellhop_bell: @conda-forge/py-maidr

https://github.com/conda-forge/py-maidr-feedstock/pull/7 adds an output for the pinned version of `plotly` to `py-maidr`