### PR TITLE
Add libtinyobjloader and tinyobjloader-python outputs to tinyobjloader

### DIFF
--- a/requests/tinyobjloader.yml
+++ b/requests/tinyobjloader.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  tinyobjloader:
+    - libtinyobjloader
+    - tinyobjloader-python


### PR DESCRIPTION
Adds `libtinyobjloader` and `tinyobjloader-python` outputs to `tinyobjloader` feedstock, to implement https://github.com/conda-forge/tinyobjloader-feedstock/issues/6, required by https://github.com/conda-forge/tinyobjloader-feedstock/pull/8 .

fyi @conda-forge/tinyobjloader 

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
