### PR TITLE
Add opentelemetry outputs for libgoogle-cloud

### DIFF
--- a/requests/libgoogle-cloud-opentelemetry.yml
+++ b/requests/libgoogle-cloud-opentelemetry.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  google-cloud-cpp-core:
+    - libgoogle-cloud-opentelemetry
+    - libgoogle-cloud-opentelemetry-devel


### PR DESCRIPTION
New feature in @conda-forge/google-cloud-cpp-core 

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
