### PR TITLE
add new arviz related outputs

### DIFF
--- a/requests/arviz.yml
+++ b/requests/arviz.yml
@@ -1,0 +1,8 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # this entry adds a package name
+  arviz-stats:
+    - arviz-stats-core
+  arviz:
+    - arviz-bokeh
+    - arviz-plotly


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

We have recently refactored the ArviZ library to allow more extensibility by users and downstream
libraries and released the 1.0 version. We are adding the most relevant bundles as extra outputs
to the recipes.

For example, arviz fully supports plotly as plotting backend as an optional dependency,
however, doing `conda install arviz plotly -c conda-forge` wouldn't work; the plotly support
also relies on the webcolors library and in more complex envs, an incompatible plotly version might
be pulled in. By adding `arviz-plotly` as an output we make installation much easier for users
that want to use plotly.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s): @aloctavodia @maresb
  * [x] Added a small description of why the output is being added.


<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
