### PR TITLE
Automatically file archive issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/archive.md
+++ b/.github/PULL_REQUEST_TEMPLATE/archive.md
@@ -13,8 +13,7 @@ Cheers and thank you for contributing to conda-forge!
 
 * [x] I want to archive a feedstock:
   * [ ] Pinged the team for that feedstock for their input.
-  * [ ] Make sure you have opened an issue on the feedstock explaining why it was archived.
-  * [ ] Linked that issue in this PR description.
+  * [ ] Specified the reason for archiving the feedstock in the request.
   * [ ] Added links to any other relevant issues/PRs in the PR description.
 
 <!--

--- a/conda_forge_admin_requests/archive_feedstock.py
+++ b/conda_forge_admin_requests/archive_feedstock.py
@@ -5,7 +5,7 @@ import requests
 from .utils import GH_ORG, get_gh_headers, raise_json_for_status
 
 
-def process_repo(repo, task):
+def process_repo(repo, task, reason=None):
     owner = GH_ORG
     headers = get_gh_headers()
 
@@ -29,6 +29,18 @@ def process_repo(repo, task):
         print(f"feedstock {repo} is already {target_status}", flush=True)
         return
 
+    if task == "archive" and reason is not None:
+        r = requests.post(
+            f"https://api.github.com/repos/{owner}/{repo}/issues",
+            headers=headers,
+            json={
+                "title": "Archive the feedstock",
+                "body": reason,
+            },
+        )
+        raise_json_for_status(r)
+        print(f"archival issue created: {r.json()['html_url']}", flush=True)
+
     r = requests.patch(
         f"https://api.github.com/repos/{owner}/{repo}",
         headers=headers,
@@ -46,7 +58,7 @@ def run(request):
     pkgs_to_do_again = []
     for feedstock in feedstocks:
         try:
-            process_repo(f"{feedstock}-feedstock", task)
+            process_repo(f"{feedstock}-feedstock", task, reason=request.get("reason"))
         except Exception as e:
             print(f"failed to {task} '{feedstock}': {e!r}", flush=True)
             pkgs_to_do_again.append(feedstock)

--- a/conda_forge_admin_requests/archive_feedstock.py
+++ b/conda_forge_admin_requests/archive_feedstock.py
@@ -37,7 +37,7 @@ def process_repo(repo, task, reason=None):
             headers=headers,
             json={
                 "title": "Archive the feedstock",
-                "body": reason,
+                "body": f"If you need to unarchive this feedstock, open a PR to unarchive at https://github.com/conda-forge/admin-requests. This feedstock has been archived for the following reason: {reason}",
             },
         )
         raise_json_for_status(r)

--- a/examples/example-archive.yml
+++ b/examples/example-archive.yml
@@ -1,6 +1,6 @@
 action: archive
 # The reason will be used to create the archival issue on the feedstock.
-# If one is already present, remove it.
+# If one is already present, remove the "reason:" key to disable creating a new issue.
 reason: >
   The project has been archived upstream.
 feedstocks:

--- a/examples/example-archive.yml
+++ b/examples/example-archive.yml
@@ -1,3 +1,7 @@
 action: archive
+# The reason will be used to create the archival issue on the feedstock.
+# If one is already present, remove it.
+reason: >
+  The project has been archived upstream.
 feedstocks:
   - cf-autotick-bot-test-package


### PR DESCRIPTION
Add a `reason` field that can be used to file the archiving issue on the feedstock automatically.

Fixes #1324