### PR TITLE
Add `openff-packmol-base` output to existing `openff-packmol` feedstock

### DIFF
--- a/requests/openff_packmol_split.yml
+++ b/requests/openff_packmol_split.yml
@@ -1,3 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
-  - openff-packmol: openff-packmol-base
+  openff-packmol:
+    - openff-packmol-base

--- a/requests/openff_packmol_split.yml
+++ b/requests/openff_packmol_split.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - openff-packmol: openff-packmol-base


### PR DESCRIPTION
I need to split this package into multiple outputs, using the fairly common `foo-base` approach. This is analogous to what I've done before in other packages, i.e. https://github.com/conda-forge/admin-requests/pull/1724. More context is at the link below, I believe everything is working except for the expected limitation, which brought me here

https://github.com/conda-forge/openff-packmol-feedstock/pull/2

This is "my" feedstock, if desired I can solicit explicit approval from my other maintainer

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s) (skipping - I am the team)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
