### PR TITLE
Enable Cirrus on feedstocks that had access to open-gpu-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ submit a PR adding your feedstock name to a new `.yml` file in `requests` folder
 
 Available opt-in resources:
 
-- Travis CI: See `examples/example-travis.yml`
-- Cirrus Runners: See `examples/example-cirrus-runners.yml`
-- Cirun: Provides integration with selected cloud providers. Check the [`conda-forge/.cirun`](https://github.com/conda-forge/.cirun) repository for more details.
+- Travis CI (`action: travis`): See `examples/example-travis.yml`
+- [Self-hosted runners for Github Actions](https://conda-forge.org/docs/how-to/advanced/self-hosted-runners/), provided by:
+  - Cirrus Runners (`action: cirrus-runners`). See `examples/example-cirrus-runners.yml`. Available runners are documented in [cirrus-runners.app> Setup> Resource classes](https://cirrus-runners.app/setup/#resource-classes). Only Linux x86 for now (e.g. `ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md`).
+  - Cirun (`action: cirun`): Provides integration with selected cloud providers. Check the [`conda-forge/.cirun`](https://github.com/conda-forge/.cirun) repository for more details.
 
 ## Request a CFEP-3 copy to conda-forge
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Available opt-in resources:
 
 - Travis CI (`action: travis`): See `examples/example-travis.yml`
 - [Self-hosted runners for Github Actions](https://conda-forge.org/docs/how-to/advanced/self-hosted-runners/), provided by:
-  - Cirrus Runners (`action: cirrus-runners`). See `examples/example-cirrus-runners.yml`. Available runners are documented in [cirrus-runners.app> Setup> Resource classes](https://cirrus-runners.app/setup/#resource-classes). Only Linux x86 for now (e.g. `ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md`).
+  - Cirrus Runners (`action: cirrus_runners`). See `examples/example-cirrus-runners.yml`. Available runners are documented in [cirrus-runners.app> Setup> Resource classes](https://cirrus-runners.app/setup/#resource-classes). Only Linux x86 for now (e.g. `ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md`).
   - Cirun (`action: cirun`): Provides integration with selected cloud providers. Check the [`conda-forge/.cirun`](https://github.com/conda-forge/.cirun) repository for more details.
 
 ## Request a CFEP-3 copy to conda-forge

--- a/conda_forge_admin_requests/__init__.py
+++ b/conda_forge_admin_requests/__init__.py
@@ -33,6 +33,7 @@ def register_actions():
     register_action("token_reset", token_reset)
     register_action("travis", access_control)
     register_action("cirun", access_control)
+    register_action("cirrus_runners", access_control)
     register_action("cfep3_copy", cfep3_copy)
     register_action("add_feedstock_output", feedstock_outputs)
     for pkg in pkgutil.iter_modules():

--- a/conda_forge_admin_requests/access_control.py
+++ b/conda_forge_admin_requests/access_control.py
@@ -163,7 +163,7 @@ def _process_request_for_feedstock(
         if action == "travis":
             register_ci_cmd.append("--with-travis")
 
-        elif action == "cirrus-runners":
+        elif action == "cirrus_runners":
             register_ci_cmd.append("--with-cirrus-runners")
             if revoke:
                 register_ci_cmd.append("--remove")
@@ -197,7 +197,7 @@ def _process_request_for_feedstock(
         if not revoke:
             if action == "travis":
                 with_cmd = "--with-travis"
-            elif action in ("cirun", "cirrus-runners"):
+            elif action in ("cirun", "cirrus_runners"):
                 with_cmd = "--with-github-actions"
 
             print("Generating a new feedstock token")
@@ -282,7 +282,7 @@ def check(request: Dict[str, Any]) -> None:
         check_if_repo_exists(feedstock)
 
     action = request["action"]
-    assert action in ("travis", "cirun", "cirrus-runners"), f"Unknown action {action}"
+    assert action in ("travis", "cirun", "cirrus_runners"), f"Unknown action {action}"
 
     if action == "cirun":
         assert "resources" in request, "No resources field in request"

--- a/examples/example-cirrus-runners.yml
+++ b/examples/example-cirrus-runners.yml
@@ -1,4 +1,4 @@
-action: cirrus-runners
+action: cirrus_runners
 feedstocks:
   # list of feedstock names (sans `-feedstock` suffix)
   - pytorch-cpu

--- a/examples/example-cirun.yml
+++ b/examples/example-cirun.yml
@@ -5,11 +5,10 @@ feedstocks:
 resources:
   # list of resource names you are applying to
   # see https://github.com/conda-forge/.cirun for available options
-  - cirun-openstack-gpu-large
-  # - cirun-openstack-cpu-large
+  - cirun-azure-windows-2xlarge
 # switch to true if you need it on pull-requests too
 pull_request: false
-# revoke access to the gpu runner
+# revoke access to the cirun runner
 revoke: false
 # Send an automatic PR to the feedstock to enable cirun defaults
 send_pr: true

--- a/requests/enable-cirrus.yml
+++ b/requests/enable-cirrus.yml
@@ -11,7 +11,7 @@ feedstocks:
   - nodejs
   - onnxruntime
   - pytorch-cpu
-  - pytorch-scatter
+  - pytorch_scatter
   - qt-webengine
   - ray-packages
   - tensorflow

--- a/requests/enable-cirrus.yml
+++ b/requests/enable-cirrus.yml
@@ -1,0 +1,26 @@
+action: cirrus-runners
+feedstocks:
+  # list of feedstock names (sans `-feedstock` suffix)
+  - astra-toolbox
+  - cutlass
+  - flash-attn
+  - jaxlib
+  - libmagma
+  - mongodb
+  - muscat-split
+  - nodejs
+  - onnxruntime
+  - pytorch-cpu
+  - pytorch-scatter
+  - qt-webengine
+  - ray-packages
+  - tensorflow
+  - tinygrad
+  - torchao
+  - viskores
+  - vllm
+  - vtk-m
+  - webkit2gtk4.1
+  - xformers
+# revoke access to the runners
+revoke: false

--- a/requests/enable-cirrus.yml
+++ b/requests/enable-cirrus.yml
@@ -1,4 +1,4 @@
-action: cirrus-runners
+action: cirrus_runners
 feedstocks:
   # list of feedstock names (sans `-feedstock` suffix)
   - astra-toolbox


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [x] Pinged the relevant feedstock team(s)
  * [ ] Added a small description explaining why access is needed

<!--
For example if you are trying to request access for the `foo` feedstock.

  ping @conda-forge/foo

-->

Comes from https://github.com/conda-forge/.cirun/pull/174

cc @conda-forge/core, @conda-forge/astra-toolbox, @conda-forge/cutlass, @conda-forge/flash-attn, @conda-forge/jaxlib, @conda-forge/libmagma, @conda-forge/mongodb, @conda-forge/muscat-split, @conda-forge/nodejs, @conda-forge/onnxruntime, @conda-forge/pytorch-cpu, @conda-forge/pytorch_scatter, @conda-forge/qt-webengine, @conda-forge/ray-packages, @conda-forge/tensorflow, @conda-forge/tinygrad, @conda-forge/torchao, @conda-forge/viskores, @conda-forge/vllm, @conda-forge/vtk-m, @conda-forge/webkit2gtk4-1 , @conda-forge/xformers.

Cirrus Runners will replace the `open-gpu-server` runners for CPU-only jobs. We have access to three concurrency units, whose cost [goes](https://cirrus-runners.app/setup/#__tabbed_3_2) as follows:

<img width="821" height="443" alt="image" src="https://github.com/user-attachments/assets/5759a240-0001-4daf-abef-22b2b2aa20b8" />

Once this is merged, you can use [`github_actions_labels`](https://conda-forge.org/docs/maintainer/conda_forge_yml/#github_actions_labels) in `recipe/conda_build_config.yaml` like this:

- `cirun-openstack-cpu-medium` users should use `ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm`
- `cirun-openstack-cpu-large` users should use `ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm`
- `cirun-openstack-cpu-xlarge` users should use `ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md`
- `cirun-openstack-cpu-2xlarge` users should use `ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg`
- `cirun-openstack-cpu-4xlarge` users should use `ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg`


For example:

```yaml
github_actions_labels:
- ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md  # [linux64]
```