### PR TITLE
Add devel outputs for Fortran feedstocks

### DIFF
--- a/requests/fortran_abi.yml
+++ b/requests/fortran_abi.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - gcp-correction: "gcp-correction-devel"
+  - fortran_stdlib: "fortran_stdlib-devel"
+  - cpcm-x: "cpxm-x-devel"
+  - fpm: "fpm-devel"

--- a/requests/fortran_abi.yml
+++ b/requests/fortran_abi.yml
@@ -1,6 +1,10 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
-  - gcp-correction: "gcp-correction-devel"
-  - fortran_stdlib: "fortran_stdlib-devel"
-  - cpcm-x: "cpxm-x-devel"
-  - fpm: "fpm-devel"
+  gcp-correction:
+    - gcp-correction-devel
+  fortran_stdlib:
+    - fortran_stdlib-devel
+  cpcm-x:
+    - cpxm-x-devel
+  fpm:
+    - fpm-devel


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

Follow-up on https://github.com/conda-forge/admin-requests/pull/1484 for supporting flang on Windows. This is necessary to allow Fortran packages link other Fortran packages don't consume incompatible ABIs produced by different compilers (gfortran, flang, ifx, lfortran).

Discussed in https://github.com/conda-forge/flang-activation-feedstock/issues/14.

ping @h-vetinari.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
For packages:
- @conda-forge/gcp-correction
- @conda-forge/fortran_stdlib
- @conda-forge/cpcm-x 
- @conda-forge/fpm 
