### PR TITLE
mark proj 9.8 as broken

### DIFF
--- a/requests/proj_9.8.yml
+++ b/requests/proj_9.8.yml
@@ -1,0 +1,7 @@
+action: broken
+packages:
+  - win-64/proj-9.8.0-hd30e2cd_0.conda
+  - osx-arm64/proj-9.8.0-hfb14a63_0.conda
+  - osx-64/proj-9.8.0-he69a98e_0.conda
+  - linux-ppc64le/proj-9.8.0-h506498c_0.conda
+  - linux-aarch64/proj-9.8.0-hd211770_0.conda


### PR DESCRIPTION
## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* You can use `pixi run find-name {matchspec}` to get a list of filenames matching given spec.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [X] Added a description of the problem with the package in the PR description.
  * [X] Pinged the team for the package for their input.

Latest proj is broken and a 9.8.1 version will be released soon. For now we should remove this to prevent bad/wrong results when using it. See https://github.com/OSGeo/PROJ/pull/4736 for more info.

Pinging @conda-forge/proj-4