### PR TITLE
Mark wombat 0.13.2 build 0 as broken (missing subpackages)

### DIFF
--- a/requests/wombat-broken.yml
+++ b/requests/wombat-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/wombat-0.13.2-pyhc364b38_0.conda


### PR DESCRIPTION
## Mark wombat 0.13.2 build 0 as broken

The `noarch/wombat-0.13.2-pyhc364b38_0.conda` package is missing the `wombat.core`, `wombat.utilities`, and `wombat.windfarm` subpackages. Only `wombat/__init__.py` and `wombat/__main__.py` are included, making the package completely non-functional:

```
>>> from wombat.core import Simulation
ModuleNotFoundError: No module named 'wombat.core'
```

**Root cause**: The recipe used a GitHub tarball as source, which lacks `PKG-INFO`. Without it, `setuptools-scm` cannot override the broken upstream `packages.find` config (`include=["wombat"]` misses `wombat.*` subpackages). The feedstock tests did not catch this because they copied the full source tree (`files: source: - .`), so pytest imported from the local source rather than the installed package.

**Fix**: A corrected build (build number 1) is in progress at conda-forge/wombat-feedstock#1, switching to the PyPI sdist source and fixing test isolation.

## Checklist:

- [x] I want to mark a package as broken (or not broken):
  - [x] Added a description of the problem with the package in the PR description.
  - [x] Pinged the team for the package for their input.

I am the only member of @conda-forge/wombat