### PR TITLE
add strawberry-graphql output strawberry-graphql-with-apollo-federation

### DIFF
--- a/requests/add-strawberry-graphql-output-strawberry-graphql-with-apollo-federation.yml
+++ b/requests/add-strawberry-graphql-output-strawberry-graphql-with-apollo-federation.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  strawberry-graphql:
+    - strawberry-graphql-with-apollo-federation


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.


@conda-forge/strawberry-graphql 

https://github.com/conda-forge/strawberry-graphql-feedstock/pull/431 adds a new output which has a pin on `protobuf`, but is called `apollo-federation` :shrug: