### PR TITLE
add pyami-core output: pyami-core-cli

### DIFF
--- a/requests/add-pyami-core-output-pyami-core-cli.yml
+++ b/requests/add-pyami-core-output-pyami-core-cli.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  pyami-core:
+    - pyami-core-cli


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/pyami-core

-->

This is to split the `pyami-core` into a python-only output and an output that ships the `cli` separately under `ami`. This will be needed for downstream packages that override the `ami` cli by default that comes from `pyami-core` (this is how `pyami` was designed in the first place).
