### PR TITLE
mark linux-64/proj-9.8.0 as broken

### DIFF
--- a/requests/proj_9.8.yml
+++ b/requests/proj_9.8.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+  - linux-64/proj-9.8.0-he0df7b0_0.conda


### PR DESCRIPTION
## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [ ] Pinged the team for the package for their input.

Follows up on #1989, which missed the linux-64 variant.

attn: @ocefpaf 