### PR TITLE
Add new output to lerobot 0.5.1

### DIFF
--- a/requests/lerobot-0-5-1.yml
+++ b/requests/lerobot-0-5-1.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  lerobot:
+    - lerobot-multi-task-dit


### PR DESCRIPTION
This PR requests adding the `lerobot-multi-task-dit` output to the `lerobot-feedstock` allowlist, as per upstream 0.5.1 release.

Related: https://github.com/conda-forge/lerobot-feedstock/pull/14

FYI @conda-forge/lerobot

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
