### PR TITLE
mark `_0` builds of pytest 9.0.3 as broken

### DIFF
--- a/requests/pytest.yml
+++ b/requests/pytest.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/pytest-9.0.3-pyhc364b38_0.conda


### PR DESCRIPTION
Builds before https://github.com/conda-forge/pytest-feedstock/pull/198 are missing colorama, which causes `pip check` to fail if the `_0` builds get pulled in