### PR TITLE
Add onemkl-license output to intel_repack-feedstock

### DIFF
--- a/requests/add-onemkl-license-to-intel-repack.yml
+++ b/requests/add-onemkl-license-to-intel-repack.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  intel_repack-feedstock:
+    - onemkl-license


### PR DESCRIPTION
 ## Checklist:

  * [x] I want to add a package output to a feedstock:
    * [x] Pinged the relevant feedstock team(s)
    * [x] Added a small description of why the output is being added.

  ## Description

  Request to add the `onemkl-license` package output to intel_repack-feedstock.
  This package was added in oneAPI 2025.3 and needs to be included in the repack.

  Related PR: conda-forge/intel_repack-feedstock#129

