### PR TITLE
Create `newton-notebook` output

### DIFF
--- a/requests/newton-notebook-v-1-1-0.yml
+++ b/requests/newton-notebook-v-1-1-0.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  newton:
+    - newton-notebook


### PR DESCRIPTION
This PR adds a new `newton-notebook` output to the `newton` package. From:
- https://github.com/conda-forge/newton-feedstock/pull/2

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
