### PR TITLE
Add gw_eccentricity-postprocess output

### DIFF
--- a/requests/gw_eccentricity-postprocess.yml
+++ b/requests/gw_eccentricity-postprocess.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  gw_eccentricity:
+    - gw_eccentricity-postprocess


### PR DESCRIPTION
# Checklist:
 - [x] I want to add a package output to a feedstock:
   - [x] Pinged the relevant feedstock team(s)
   - [x] Added a small description of why the output is being added.
# Description
Request to add the `gw_eccentricity-postprocess` package output to gw_eccentricity-feedstock.
This subpackage for post-processing eccentricity measurements from GW posterior samples 
was added in v2.1.0 and needs to be included in gw_eccentricity-feedstock.
Related PR: https://github.com/conda-forge/admin-requests/pull/2021

@conda-forge/gw_eccentricity
