### PR TITLE
Add sfincs-openmpi output

### DIFF
--- a/requests/add-sfincs-openmpi-output.yml
+++ b/requests/add-sfincs-openmpi-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  sfincs:
+    - sfincs-openmpi


### PR DESCRIPTION
* In https://github.com/conda-forge/staged-recipes/pull/32959/ three outputs were intended to be generated from the feedstock: `sfincs`, `sfincs-mpich`, and `sfincs-openmpi`. `sfincs` and `sfincs-mpich` were generated correctly for https://github.com/conda-forge/sfincs-feedstock but `sfincs-openmpi` seems to not have been. This PR attempts to add this missing output.
* c.f. [#general > noarch: generic metapackage failing to upload to conda-forge](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/noarch.3A.20generic.20metapackage.20failing.20to.20upload.20to.20conda-forge/with/585918698)

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
   - I am a maintainer for @conda-forge/sfincs.
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
