### PR TITLE
MNT: Add unpatched version and ZIG support

### DIFF
--- a/requests/qemu-execve.yaml
+++ b/requests/qemu-execve.yaml
@@ -1,0 +1,11 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  qemu-execve:
+    - qemu-user-linux-aarch64
+    - qemu-user-linux-ppc64le
+    - qemu-user-linux-riscv64
+    - qemu-user-linux-s390x
+    - qemu-zig-linux-aarch64
+    - qemu-zig-linux-ppc64le
+    - qemu-zig-linux-riscv64
+    - qemu-zig-linux-s390x


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

QEMU-execve applies a unsupported patch to add redirection of `execve()` calls to itself rather than to the native dynamic loader. It may be useful for users to have access to the un-patched QEMU.

The `qemu-zig` adds additional ZIG patches to enhance QEMU for more integrated use when compiling with the ZIG compiler. It is directed to be installed in `${PREFIX}/lib/qemu-zig/` folder that conda ZIG has been upgraded to use

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
Related PR:
https://github.com/conda-forge/qemu-execve-feedstock/pull/23