### PR TITLE
Grant access to Namespace and Blacksmith to repos using macOS and Windows runners on cirun

### DIFF
--- a/requests/move-from-cirun-windows-macos-bs.yml
+++ b/requests/move-from-cirun-windows-macos-bs.yml
@@ -3,7 +3,7 @@ feedstocks:
   # list of feedstock names (sans `-feedstock` suffix)
   - clangdev
   - gstreamer
-  - llamacpp
+  - llama-cpp
   - llvmdev
   - openvino
   - pixi-pack

--- a/requests/move-from-cirun-windows-macos-bs.yml
+++ b/requests/move-from-cirun-windows-macos-bs.yml
@@ -3,7 +3,7 @@ feedstocks:
   # list of feedstock names (sans `-feedstock` suffix)
   - clangdev
   - gstreamer
-  - llama-cpp
+  - llama.cpp
   - llvmdev
   - openvino
   - pixi-pack

--- a/requests/move-from-cirun-windows-macos-bs.yml
+++ b/requests/move-from-cirun-windows-macos-bs.yml
@@ -1,0 +1,12 @@
+action: blacksmith
+feedstocks:
+  # list of feedstock names (sans `-feedstock` suffix)
+  - clangdev
+  - gstreamer
+  - llamacpp
+  - llvmdev
+  - openvino
+  - pixi-pack
+  - temporalio-cli
+# revoke access to the runners
+revoke: false

--- a/requests/move-from-cirun-windows-macos-ns.yml
+++ b/requests/move-from-cirun-windows-macos-ns.yml
@@ -3,7 +3,7 @@ feedstocks:
   # list of feedstock names (sans `-feedstock` suffix)
   - clangdev
   - gstreamer
-  - llamacpp
+  - llama-cpp
   - llvmdev
   - openvino
   - pixi-pack

--- a/requests/move-from-cirun-windows-macos-ns.yml
+++ b/requests/move-from-cirun-windows-macos-ns.yml
@@ -3,7 +3,7 @@ feedstocks:
   # list of feedstock names (sans `-feedstock` suffix)
   - clangdev
   - gstreamer
-  - llama-cpp
+  - llama.cpp
   - llvmdev
   - openvino
   - pixi-pack

--- a/requests/move-from-cirun-windows-macos-ns.yml
+++ b/requests/move-from-cirun-windows-macos-ns.yml
@@ -1,0 +1,12 @@
+action: namespace
+feedstocks:
+  # list of feedstock names (sans `-feedstock` suffix)
+  - clangdev
+  - gstreamer
+  - llamacpp
+  - llvmdev
+  - openvino
+  - pixi-pack
+  - temporalio-cli
+# revoke access to the runners
+revoke: false


### PR DESCRIPTION
With these two providers, I don't think we need to keep the Prefix-sponsored runners around.
See available runners at https://github.com/conda-forge/admin-requests#larger-runners-for-github-actions

cc @conda-forge/clangdev, @conda-forge/gstreamer, @conda-forge/llama-cpp, @conda-forge/llvmdev, @conda-forge/openvino, @conda-forge/pixi-pack, @conda-forge/temporalio-cli.