### PR TITLE
Archive vtk-m feedstock

### DIFF
--- a/requests/archive-vtk-m.yml
+++ b/requests/archive-vtk-m.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - vtk-m


### PR DESCRIPTION
vtk-m has been superseded by Viskores, which has its own feedstock. No packages in conda-forge currently depend on vtk-m. vtk-m will have no further releases; its final release was ~one year ago.