### PR TITLE
Add rust-std-x86_64-pc-windows-gnu to rust-feedstock

### DIFF
--- a/requests/x86_64-pc-windows-gnu.yml
+++ b/requests/x86_64-pc-windows-gnu.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  rust:
+    - rust-std-x86_64-pc-windows-gnu


### PR DESCRIPTION

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description of why the output is being added.
