### PR TITLE
add dagster output dagster-rest-resources

### DIFF
--- a/requests/add-dagster-output-dagster-rest-resources.yml
+++ b/requests/add-dagster-output-dagster-rest-resources.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  dagster:
+    - dagster-rest-resources


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/dagster @conda-forge/dagster-libs

On https://github.com/conda-forge/dagster-feedstock/pull/510 the existing `dagster-dg-cli` now [depends on](https://github.com/conda-forge/dagster-feedstock/pull/510/changes#diff-ad6aed43f0cf479348ccccec8e7185c4b70582192329f11908dd22a731771702R280) the new first-party `dagster-rest-resources`. Awkwardly, this is a "stable" version (owned by `dagster-feedstock`) which depends on an "unstable" version (usually owned by `dagster-libs-feedstock`), but presumably the version will line up at some point in the future.