### PR TITLE
Add docling-slim output to docling

### DIFF
--- a/requests/add-docling-slim.yml
+++ b/requests/add-docling-slim.yml
@@ -1,4 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
   docling:
-    docling-slim
+    - docling-slim

--- a/requests/add-docling-slim.yml
+++ b/requests/add-docling-slim.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  docling:
+    docling-slim


### PR DESCRIPTION
`docling` comes with many optional dependencies, many of which have not very permissive licenses. Therefore I would like to add a `docling-slim` output with [this PR](https://github.com/conda-forge/docling-feedstock/pull/72), only including necessary dependencies.

Related PR: https://github.com/docling-project/docling/pull/3285

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
