### PR TITLE
add hf-mount-fuse output to hf-mount

### DIFF
--- a/requests/add-hf-mount-fuse-output-hf-mount.yml
+++ b/requests/add-hf-mount-fuse-output-hf-mount.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  hf-mount:
+    - hf-mount-fuse


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->

https://github.com/conda-forge/hf-mount-feedstock/pull/5
There are two versions of hf-mount: NFS and FUSE. This addition was made to include the FUSE version in addition to the existing NFS version.