### PR TITLE
Add outputs from sagelib-feedstock to sage-feedstock

### DIFF
--- a/requests/add-sage-output.yml
+++ b/requests/add-sage-output.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  sage:
+    - sagelib
+    - sagemath-bliss
+    - sagemath-sirocco


### PR DESCRIPTION
As [discussed previously](https://github.com/conda-forge/sagelib-feedstock/issues/169#issuecomment-1851325852) with @isuruf, there is no need anymore to split sage into sage-feedstock and sagelib-feedstock. We move the contents of the sagelib-feedstock into the sage-feedstock in https://github.com/conda-forge/sage-feedstock/pull/129.

To make this possible, we need to add the three sagelib outputs to sage.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s); yes pinged above, the other maintainer hasn't been active for quite a while.
  * [x] Added a small description of why the output is being added.

