### PR TITLE
Add spla-static output to spla

### DIFF
--- a/requests/add_spla-static_output.yaml
+++ b/requests/add_spla-static_output.yaml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  spla:
+    - spla-static


### PR DESCRIPTION
Add output name `spla-static` to `spla` for a static library version in addition to the existing shared one `spla`.

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
