### PR TITLE
add jupyterlite-pyodide-kernel output jupyterlite-pyodide-kernel-with-lock

### DIFF
--- a/requests/add-jupyterlite-pyodide-kernel-output-jupyterlite-pydodide-kernel-with-lock.yml
+++ b/requests/add-jupyterlite-pyodide-kernel-output-jupyterlite-pydodide-kernel-with-lock.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  jupyterlite-pyodide-kernel:
+    - jupyterlite-pydodide-kernel-with-lock

--- a/requests/add-jupyterlite-pyodide-kernel-output-jupyterlite-pydodide-kernel-with-lock.yml
+++ b/requests/add-jupyterlite-pyodide-kernel-output-jupyterlite-pydodide-kernel-with-lock.yml
@@ -1,4 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
   jupyterlite-pyodide-kernel:
-    - jupyterlite-pydodide-kernel-with-lock
+    - jupyterlite-pyodide-kernel-with-lock


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/jupyterlite-pyodide-kernel 

https://github.com/conda-forge/jupyterlite-pyodide-kernel-feedstock/pull/81 adds a new `-with-lock` output to `jupyterlite-pyodide-kernel` which depends on `pyodide-kernel-with-uv`.