### PR TITLE
Add runner storage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,25 +90,25 @@ Available opt-in resources:
 
 Github Actions labels for `conda_build_config.yaml`:
 
-| `github_actions_labels` value              | Platform        | CPUs    | RAM   |
-| :----------------------------------------- | :-------------: | :-----: | :---: |
-| `namespace-profile-8cpu-on-linux-64`       | `linux-64`      | 8       | 32 GB |
-| `namespace-profile-16cpu-on-linux-64`      | `linux-64`      | 16      | 64 GB |
-| `namespace-profile-8cpu-on-linux-aarch64`  | `linux-aarch64` | 8       | 32 GB |
-| `namespace-profile-16cpu-on-linux-aarch64` | `linux-aarch64` | 16      | 64 GB |
-| `namespace-profile-6cpu-on-osx-arm64`      | `osx-arm64`     | 6       | 14 GB |
-| `namespace-profile-12cpu-on-osx-arm64`     | `osx-arm64`     | 12      | 28 GB |
-| `namespace-profile-8cpu-on-win-64`         | `win-64`        | 8       | 32 GB |
-| `namespace-profile-16cpu-on-win-64`        | `win-64`        | 16      | 64 GB |
+| `github_actions_labels` value              | Platform        | CPUs    | RAM   | Storage |
+| :----------------------------------------- | :-------------: | :-----: | :---: | :-----: |
+| `namespace-profile-8cpu-on-linux-64`       | `linux-64`      | 8       | 32 GB | 160 GB  |
+| `namespace-profile-16cpu-on-linux-64`      | `linux-64`      | 16      | 64 GB | 288 GB  |
+| `namespace-profile-8cpu-on-linux-aarch64`  | `linux-aarch64` | 8       | 32 GB | 160 GB  |
+| `namespace-profile-16cpu-on-linux-aarch64` | `linux-aarch64` | 16      | 64 GB | 288 GB  |
+| `namespace-profile-6cpu-on-osx-arm64`      | `osx-arm64`     | 6       | 14 GB | 104 GB  |
+| `namespace-profile-12cpu-on-osx-arm64`     | `osx-arm64`     | 12      | 28 GB | 160 GB  |
+| `namespace-profile-8cpu-on-win-64`         | `win-64`        | 8       | 32 GB | 160 GB  |
+| `namespace-profile-16cpu-on-win-64`        | `win-64`        | 16      | 64 GB | 288 GB  |
 | | | | |
-| `blacksmith-8vcpu-ubuntu-2404`             | `linux-64`      | 8       | 32 GB |
-| `blacksmith-16vcpu-ubuntu-2404`            | `linux-64`      | 16      | 64 GB |
-| `blacksmith-8vcpu-ubuntu-2404-arm`         | `linux-aarch64` | 8       | 24 GB |
-| `blacksmith-16vcpu-ubuntu-2404-arm`        | `linux-aarch64` | 16      | 48 GB |
-| `blacksmith-6vcpu-macos-latest`            | `osx-arm64`     | 6       | 24 GB |
-| `blacksmith-12vcpu-macos-latest`           | `osx-arm64`     | 12      | 48 GB |
-| `blacksmith-8vcpu-windows-2025`            | `win-64`        | 8       | 28 GB |
-| `blacksmith-16vcpu-windows-2025`           | `win-64`        | 16      | 56 GB |
+| `blacksmith-8vcpu-ubuntu-2404`             | `linux-64`      | 8       | 32 GB | 160 GB  |
+| `blacksmith-16vcpu-ubuntu-2404`            | `linux-64`      | 16      | 64 GB | 750 GB  |
+| `blacksmith-8vcpu-ubuntu-2404-arm`         | `linux-aarch64` | 8       | 24 GB | 160 GB  |
+| `blacksmith-16vcpu-ubuntu-2404-arm`        | `linux-aarch64` | 16      | 48 GB | 750 GB  |
+| `blacksmith-6vcpu-macos-latest`            | `osx-arm64`     | 6       | 24 GB | 150 GB  |
+| `blacksmith-12vcpu-macos-latest`           | `osx-arm64`     | 12      | 48 GB | 250 GB  |
+| `blacksmith-8vcpu-windows-2025`            | `win-64`        | 8       | 28 GB | 130 GB  |
+| `blacksmith-16vcpu-windows-2025`           | `win-64`        | 16      | 56 GB | 130 GB  |
 
 > Other providers may be available via [cirun.io](https://cirun.io) (`action: cirun`). Check the [`conda-forge/.cirun`](https://github.com/conda-forge/.cirun) repository for more details. See `examples/example-cirun.yml`.
 


### PR DESCRIPTION
seems hit the storage limit on namespace with qt-webengine so it may be useful to add storage capacity

source:
https://docs.blacksmith.sh/blacksmith-runners/overview


for namespace I asked their AI:
The storage capacity (ephemeral disk) for each runner depends on the machine shape you select[1](https://namespace.so/docs/architecture/compute/machine-shapes).

Namespace automatically provisions ephemeral storage based on your selected machine shape[1](https://namespace.so/docs/architecture/compute/machine-shapes). The storage allocation scales dynamically to ensure adequate disk space for your workload[1](https://namespace.so/docs/architecture/compute/machine-shapes).
Linux & Windows Storage Allocation

Here are some common configurations[1](https://namespace.so/docs/architecture/compute/machine-shapes):

    2x4 (2 vCPU, 4 GB RAM): 48 GB disk
    4x8 (4 vCPU, 8 GB RAM): 64 GB disk
    4x16 (4 vCPU, 16 GB RAM): 96 GB disk
    8x16 (8 vCPU, 16 GB RAM): 96 GB disk
    8x32 (8 vCPU, 32 GB RAM): 160 GB disk
    16x32 (16 vCPU, 32 GB RAM): 160 GB disk
    16x64 (16 vCPU, 64 GB RAM): 288 GB disk
    32x64 (32 vCPU, 64 GB RAM): 288 GB disk
    32x128 (32 vCPU, 128 GB RAM): 544 GB disk
    32x256 (32 vCPU, 256 GB RAM): 1056 GB disk
    32x512 (32 vCPU, 512 GB RAM): 2080 GB disk

For non-standard shapes, the provisioned ephemeral disk space for an instance is calculated using the following formula[1](https://namespace.so/docs/architecture/compute/machine-shapes):

disk_size = 32GB + (max(vCPU_count, RAM_GB / 2)) * 8GB
macOS Storage Allocation

For macOS instances, free space scales with their shapes too[1](https://namespace.so/docs/architecture/compute/machine-shapes). It starts at 48 GB and each 1x2 unit adds 8 GB[1](https://namespace.so/docs/architecture/compute/machine-shapes):

    6x14 (6 vCPU, 14 GB RAM): 104 GB disk
    12x28 (12 vCPU, 28 GB RAM): 160 GB disk
    12x56 (12 vCPU, 56 GB RAM): 272 GB disk