### PR TITLE
Add spfft-static output to spfft

### DIFF
--- a/requests/add_spfft-static_output.yaml
+++ b/requests/add_spfft-static_output.yaml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  spfft:
+    - spfft-static


### PR DESCRIPTION
Add spfft-static output name for static `spfft` library build in addition to the existing shared library build `spla`.
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
