### PR TITLE
Archive two apache-airflow feedstock and add outputs to main feedstock

### DIFF
--- a/requests/add-apache-airflow-outputs.yml
+++ b/requests/add-apache-airflow-outputs.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  airflow:
+    - apache-airflow-core
+    - apache-airflow-core-with-all
+    - apache-airflow-task-sdk

--- a/requests/archive-apache-airflow-core-task-sdk.yml
+++ b/requests/archive-apache-airflow-core-task-sdk.yml
@@ -1,0 +1,4 @@
+action: archive
+feedstocks:
+  - apache-airflow-core-split
+  - apache-airflow-task-sdk


### PR DESCRIPTION
This PR achrives `apache-airflow-core-split` and `apache-airflow-task-sdk` and adds their outputs instead to the main airflow-feedstock.

This is necessary because these packages have circular dependencies on each other, as detailed in:
https://github.com/conda-forge/airflow-feedstock/issues/181 and posted as well at:
https://github.com/conda-forge/apache-airflow-core-split-feedstock/issues/22 and
https://github.com/conda-forge/apache-airflow-task-sdk-feedstock/issues/47

The circular dependencies have been resolved in:
https://github.com/conda-forge/airflow-feedstock/pull/179 which is expected work as soon as the outputs are moved.


## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added

ping:
- @conda-forge/airflow 
- @conda-forge/apache-airflow-core-split 
- @conda-forge/apache-airflow-task-sdk 