### PR TITLE
add jupyter-builder output jupyter-builder-with-nodejs

### DIFF
--- a/requests/add-jupyter-builder-output-jupyter-builder-with-nodejs.yml
+++ b/requests/add-jupyter-builder-output-jupyter-builder-with-nodejs.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  jupyter-builder:
+    - jupyter-builder-with-nodejs


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [ ] Pinged the relevant feedstock team(s)
  * [ ] Added a small description of why the output is being added.

ping @conda-forge/jupyterlab @conda-forge/jupyter-builder

https://github.com/conda-forge/jupyterlab-feedstock/pull/519 is starting the migration of `nodejs`-related stuff to `jupyter-builder`. 

As part of the point of `jupyter-builder` in the first place is to reduce the number of cases where "regular" users need `nodejs`, and `jupyterlab` now has a runtime dependency on `jupyter-builder`, this new output would allow for being more explicit when split between `host` and `run` for full apps, added in https://github.com/conda-forge/jupyter-builder-feedstock/pull/2 moves this forward.
