### PR TITLE
Archive pytorch-lightning for the moment due to shai-hulud

### DIFF
--- a/requests/pytorch-lightning-archive.yml
+++ b/requests/pytorch-lightning-archive.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - pytorch-lightning


### PR DESCRIPTION
Upstream pytorch-lightning is shai-hulud compromised. I think we should archive the feedstock

https://github.com/conda-forge/pytorch-lightning-feedstock/issues/177
https://semgrep.dev/blog/2026/malicious-dependency-in-pytorch-lightning-used-for-ai-training/

## Checklist:

* [x] I want to archive a feedstock:
 * [X] Pinged the team for that feedstock for their input.
 * [X] Make sure you have opened an issue on the feedstock explaining why it was archived.
 * [X] Linked that issue in this PR description.

ping @conda-forge/pytorch-lightning 
