### PR TITLE
Mark prerelease `footbridge` packages as broken

### DIFF
--- a/requests/footbridge-broken.yml
+++ b/requests/footbridge-broken.yml
@@ -1,0 +1,5 @@
+action: broken
+packages:
+- noarch/footbridge-1.0.9-pyhc364b38_2.conda
+- noarch/footbridge-1.0.9-pyhc364b38_1.conda
+- noarch/footbridge-1.0.9-pyhc364b38_0.conda


### PR DESCRIPTION
1.0.9 package itself has problems not just dependencies