### PR TITLE
Add apache-sedona-core output to apache-sedona feedstock

### DIFF
--- a/requests/add-apache-sedona-core-output.yml
+++ b/requests/add-apache-sedona-core-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  apache-sedona:
+    - apache-sedona-core


### PR DESCRIPTION
Registers `apache-sedona-core` as an allowed output of the existing `apache-sedona` feedstock.

Context: https://github.com/conda-forge/apache-sedona-feedstock/pull/33 splits the recipe into a multi-output build that produces both `apache-sedona-core` (lightweight, no PySpark / GDAL) and `apache-sedona` (metapackage adding the Spark dependency stack), per @traversaro's review on https://github.com/conda-forge/staged-recipes/pull/33194. Output validation currently rejects the new `apache-sedona-core` output until it's registered here.