### PR TITLE
add jupyterlab-git output jupyterlab-git-core

### DIFF
--- a/requests/add-jupyterlab-git-output-jupyterlab-git-core.yml
+++ b/requests/add-jupyterlab-git-output-jupyterlab-git-core.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  jupyterlab-git:
+    - jupyterlab-git-core


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/jupyterlab-git


https://github.com/conda-forge/jupyterlab-git-feedstock/pull/90 adds a new output `jupyterlab-git-core`, cut from a new upstream sdist, but the same repo: https://github.com/jupyterlab/jupyterlab-git/releases/tag/v0.53.0 .