### PR TITLE
add py-maidr output py-maidr-with-altair

### DIFF
--- a/requests/add-py-maidr-output-py-maidr-with-altair.yml
+++ b/requests/add-py-maidr-output-py-maidr-with-altair.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  py-maidr:
+    - py-maidr-with-altair


### PR DESCRIPTION

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

  ping @conda-forge/py-maidr


https://github.com/conda-forge/py-maidr-feedstock/pull/15 adds a new output with a relatively recent pin of `altair`
