### PR TITLE
Add debug output to tango C++ packages

### DIFF
--- a/requests/tango-debug-outputs.yml
+++ b/requests/tango-debug-outputs.yml
@@ -1,0 +1,12 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  tango-admin:
+    - tango-admin-dbg
+  tango-database:
+    - tango-database-dbg
+  tango-starter:
+    - tango-starter-dbg
+  libhdbpp:
+    - libhdbpp-dbg
+  hdbpp-cm:
+    - hdbpp-cm-dbg


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

We already have a separate package with debug symbols for some packages like [cpptango](https://github.com/conda-forge/cpptango-feedstock). We'd like to do the same for the following Tango C++ packages:
- tango-admin
- tango-database
- tango-starter
- libhdbpp
- hdbpp-cm

I started some PRs: https://github.com/conda-forge/hdbpp-cm-feedstock/pull/8 and https://github.com/conda-forge/tango-admin-feedstock/pull/23 that are failing because the output isn't allowed. I thought I'd make one PR in this repos for all the packages I want to add.

 ping @conda-forge/tango-admin @conda-forge/tango-database @conda-forge/tango-starter @conda-forge/libhdbpp @conda-forge/hdbpp-cm 
