### PR TITLE
Add libgdcm and libgdcm-devel outputs for gdcm-feedstock

### DIFF
--- a/requests/add-gdcm-outputs.yml
+++ b/requests/add-gdcm-outputs.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  gdcm:
+    - libgdcm
+    - libgdcm-devel


### PR DESCRIPTION
This adds the two new package outputs introduced in conda-forge/gdcm-feedstock#65.

The PR refactors the single `gdcm` package into three outputs:
- `libgdcm`: shared libraries only
- `libgdcm-devel`: headers and CMake config files
- `gdcm`: Python bindings (already registered)

Without this, CI fails at the output validation step with:
```
"linux-64/libgdcm-3.2.4-..._0.conda": false,
"linux-64/libgdcm-devel-3.2.4-..._0.conda": false
```

Related feedstock PR: conda-forge/gdcm-feedstock#65