### PR TITLE
add pypdf output pypdf-with-fonts

### DIFF
--- a/requests/add-pypdf-output-pypdf-with-fonts.yml
+++ b/requests/add-pypdf-output-pypdf-with-fonts.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  pypdf:
+    - pypdf-with-fonts


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/pypdf

On https://github.com/conda-forge/pypdf-feedstock/pull/100, upstream added a new optional dependency on `fonttools`.
