### PR TITLE
add cleopatra-tiles

### DIFF
--- a/requests/add-cleopatra-output-cleopatra-tiles.yml
+++ b/requests/add-cleopatra-output-cleopatra-tiles.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  cleopatra:
+    - cleopatra-tiles


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

This PR registers `cleopatra-tiles` as an additional output of the existing `cleopatra-feedstock`. `cleopatra-tiles` is a metapackage matching the new `pip install "cleopatra[tiles]"` extra (mercantile, xyzservices, pillow, pyproj) used by the `cleopatra.tiles` module for web-tile basemaps. The multi-output recipe is already merged on the feedstock; it fails `validate_recipe_outputs` until this mapping is registered.

Feedstock: https://github.com/conda-forge/cleopatra-feedstock
Failing CI run: https://github.com/conda-forge/cleopatra-feedstock/actions/runs/25697263369

ping @conda-forge/cleopatra
