### PR TITLE
fix: Mark all of pixi-build-python==0.4.9 broken

### DIFF
--- a/requests/pixi-build-python.yml
+++ b/requests/pixi-build-python.yml
@@ -1,0 +1,7 @@
+action: broken
+packages:
+- linux-64/pixi-build-python-0.4.9-h993bfcc_0.conda
+- linux-aarch64/pixi-build-python-0.4.9-h50215e9_0.conda
+- osx-64/pixi-build-python-0.4.9-h212e2c2_0.conda
+- osx-arm64/pixi-build-python-0.4.9-h8e4c5dd_0.conda
+- win-64/pixi-build-python-0.4.9-h9d14792_0.conda


### PR DESCRIPTION
This should have been pixi-build-python 0.5.0, as it has API-incompatibilities.

## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.
