### PR TITLE
Extend intel repack to include dal-gpu

### DIFF
--- a/requests/add-intel_repack-output-dal-gpu.yml
+++ b/requests/add-intel_repack-output-dal-gpu.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  intel_repack:
+    - dal-gpu


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [X] Pinged the relevant feedstock team(s)
  * [X] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/intel_repack 

-->
Adds dal-gpu because dal was split into CPU and GPU variants, with dal remaining as the CPU