### PR TITLE
Token reset for python-ldap

### DIFF
--- a/requests/python-ldap-token-reset.yml
+++ b/requests/python-ldap-token-reset.yml
@@ -1,0 +1,3 @@
+action: token_reset
+feedstocks:
+- python-ldap


### PR DESCRIPTION
Under GitHub Actions (but not Azure) we are seeing:
```
  Unauthorized: ('Authorization token is no longer valid', 401)
  To see a more detailed error message run the command again as
    anaconda --verbose --quiet --show-traceback -t /tmp/tmp5g5trprh/binstar.token upload /home/conda/feedstock_root/build_artifacts/linux-64/python-ldap-3.4.6-py314h0f05182_0.conda --user=cf-staging --channel=main --force-metadata-update
  Failed to upload due to Command '['anaconda', '--quiet', '--show-traceback', '-t', '/tmp/tmp5g5trprh/binstar.token', 'upload', '/home/conda/feedstock_root/build_artifacts/linux-64/python-ldap-3.4.6-py314h0f05182_0.conda', '--user=cf-staging', '--channel=main', '--force-metadata-update']' returned non-zero exit status 1.. Trying again in 10 seconds
  Using STAGING_BINSTAR_TOKEN for anaconda.org uploads to cf-staging.
```
See https://github.com/conda-forge/python-ldap-feedstock/actions/runs/25866141381/job/76008637894

An attempt to push an empty commit and to rerender do not seem to have helped:
https://github.com/conda-forge/python-ldap-feedstock/commits/main/
