### PR TITLE
add `fastmcp-slim` output to `fastmcp`

### DIFF
--- a/requests/add-fastmcp-slim-output.yaml
+++ b/requests/add-fastmcp-slim-output.yaml
@@ -2,4 +2,3 @@ action: add_feedstock_output
 feedstock_to_output_mapping:
   fastmcp:
     - fastmcp-slim
-

--- a/requests/add-fastmcp-slim-output.yaml
+++ b/requests/add-fastmcp-slim-output.yaml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  fastmcp:
+    - fastmcp-slim
+


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->

The `fastmcp` package was split in `3.3.0` to build `fastmcp-slim` separately. I'm adding the second output here: https://github.com/conda-forge/fastmcp-feedstock/pull/42

ping @conda-forge/fastmcp