### PR TITLE
Add libonnx output to the onnx feedstock

### DIFF
--- a/requests/add-onnx-output-libonnx.yml
+++ b/requests/add-onnx-output-libonnx.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  onnx:
+    - libonnx


### PR DESCRIPTION
I would love to make libonnx an official output in https://github.com/conda-forge/onnx-feedstock/pull/146 still working through some details, but this is going to be part of the solution

<details><summary>Claude's draft</summary>

The onnx feedstock (conda-forge/onnx-feedstock) is being split into two outputs: libonnx (the C++ shared library) and onnx (the Python package). Register libonnx as an allowed output of the onnx feedstock.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Resume this Claude session:
```
claude --resume 067936c4-ac8e-4efd-9b8f-f1df4388e87d
```
</details>




## Template selection

Please go to the "Preview" tab and select the appropriate template:

* [I want to mark a package as broken (or not broken)](?expand=1&template=broken.md)
* [I want to archive a feedstock](?expand=1&template=archive.md)
* [I want to request (or revoke) access to an opt-in CI resource](?expand=1&template=ci-resource.md)
* [I want to copy an artifact following CFEP-3](?expand=1&template=cfep-3.md)
* [I want to add a package output to a feedstock](?expand=1&template=add-feedstock-output.md)
