### PR TITLE
Add libcoremltools output to the coremltools feedstock

### DIFF
--- a/requests/add-coremltools-output-libcoremltools.yml
+++ b/requests/add-coremltools-output-libcoremltools.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  coremltools:
+    - libcoremltools


### PR DESCRIPTION
Register `libcoremltools` as an allowed output of the `coremltools` feedstock, so the CoreML C++ library split in conda-forge/coremltools-feedstock#35 can pass output validation.

<details><summary>Claude's draft</summary>

The coremltools feedstock (conda-forge/coremltools-feedstock) is being split into two outputs: `coremltools` (the existing Python package) and `libcoremltools` (a new C++ shared library + headers, macOS only). Register `libcoremltools` as an allowed output of the `coremltools` feedstock.

See conda-forge/coremltools-feedstock#35.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Resume this Claude session:
```
claude --resume cddc3bcd-9a3e-4dd2-ad9e-6ff54036dd64
```
</details>

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/coremltools