### PR TITLE
add earthlens-s3, earthlens-ecmwf, earthlens-gee, earthlens-all

### DIFF
--- a/requests/add-earthlens-outputs.yml
+++ b/requests/add-earthlens-outputs.yml
@@ -1,0 +1,7 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  earthlens:
+    - earthlens-s3
+    - earthlens-ecmwf
+    - earthlens-gee
+    - earthlens-all


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

This PR registers `earthlens-s3`, `earthlens-ecmwf`, `earthlens-gee`, and `earthlens-all` as additional outputs of the existing `earthlens-feedstock`. They are metapackages matching the new `pip install "earthlens[s3|ecmwf|gee|all]"` extras (boto3 for the ERA5-on-S3 backend, cdsapi for the ECMWF / CDS backend, earthengine-api + rtree for Google Earth Engine, and an `-all` umbrella that pulls in every optional backend) introduced in the 0.5.0 release. The multi-output recipe is being prepared on the feedstock; it will fail `validate_recipe_outputs` until this mapping is registered.

Feedstock: https://github.com/conda-forge/earthlens-feedstock

ping @conda-forge/earthlens