### PR TITLE
ADD: zig cross-compilers

### DIFF
--- a/requests/zig.yaml
+++ b/requests/zig.yaml
@@ -1,0 +1,7 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  zig:
+    - zig_linux-s390x
+    - zig_win-32
+    - zig_impl_linux-s390x
+    - zig_impl_win-32


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ZIG is already a multi-target cross-compiler, we just need the wrapper packages

@jaimergp This is related to the fix I am implementing for atexit (arm64) and win-32 target (folding s390x in the mix)
