### PR TITLE
FEA: zig supporting libs

### DIFF
--- a/requests/zig.yaml
+++ b/requests/zig.yaml
@@ -5,7 +5,3 @@ feedstock_to_output_mapping:
     - zig-llvm
     - "zig-libllvm*"
     - zig-tblgen
-    # Temporarily for riscv64
-    - zig-libxml2
-    - zig-zlib
-    - zig-zstd

--- a/requests/zig.yaml
+++ b/requests/zig.yaml
@@ -1,0 +1,11 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  zig:
+    - zig-libcxx
+    - zig-llvm
+    - "zig-libllvm*"
+    - zig-tblgen
+    # Temporarily for riscv64
+    - zig-libxml2
+    - zig-zlib
+    - zig-zstd


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

@wolfv as agreed

This adds limited scoped supporting libraries for zig decoupling from GCC/LLVM(stdc++)
zig-libxml2, zig-zstd, zig-zlib are intended only for RISCV64 until arch builds are available on conda-forge