### PR TITLE
Add output runner-intel to feedstock conda-forge/runner-feedstock

### DIFF
--- a/requests/runner_add_intel.yml
+++ b/requests/runner_add_intel.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  runner:
+    - runner-intel


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/runner-feedstock

**Description:**
Adding `runner-intel` as a new authorized output to the `runner-feedstock`. This allows us to publish a parallel, Intel-optimized variant compiled with `ifx` and `mkl` alongside our standard GNU/OpenBLAS build, all from the same feedstock.