### PR TITLE
add pyramids-stac

### DIFF
--- a/requests/add-pyramids-output-pyramids-stac.yml
+++ b/requests/add-pyramids-output-pyramids-stac.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  pyramids:
+    - pyramids-stac


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

This PR registers `pyramids-stac` as an additional output of the existing `pyramids-feedstock`.
`pyramids-stac` is a metapackage matching the new `pip install "pyramids-gis[stac]"` extra
(pystac-client) used by the STAC support added in the 0.21.0 release. The multi-output recipe is
already merged on the feedstock; it fails `validate_recipe_outputs` until this mapping is registered.

Feedstock: https://github.com/conda-forge/pyramids-feedstock
Failing CI run: https://github.com/conda-forge/pyramids-feedstock/actions/runs/26319761588

ping @conda-forge/pyramids
