### PR TITLE
Mark nebi and nebi-desktop linux-64 0.10.5 and 0.11 as broken

### DIFF
--- a/requests/nebi-linux-broken.yml
+++ b/requests/nebi-linux-broken.yml
@@ -1,0 +1,6 @@
+action: broken
+packages:
+- linux-64/nebi-desktop-0.10.5-h3250057_0.conda
+- linux-64/nebi-desktop-0.11-h3250057_0.conda
+- linux-64/nebi-0.10.5-hfc2019e_0.conda
+- linux-64/nebi-0.11-hfc2019e_0.conda


### PR DESCRIPTION
### Summary

Marking the following four files broken — `nebi-desktop` (linux-64) and the `nebi` umbrella metapackage (linux-64) for versions **0.10.5** and **0.11**:

```
linux-64/nebi-desktop-0.10.5-h3250057_0.conda
linux-64/nebi-desktop-0.11-h3250057_0.conda
linux-64/nebi-0.10.5-hfc2019e_0.conda
linux-64/nebi-0.11-hfc2019e_0.conda
```

`nebi-cli` (linux-64) is **unaffected** and stays on `main` — the CLI does not link WebKitGTK. macOS and Windows builds of all three outputs are unaffected and stay on `main`.

### Why broken

`nebi-desktop` on linux-64 crashes within ~1–2 seconds of launch on any system with `libwebkit2gtk-4.1 >= 2.46` (e.g. Ubuntu 24.04+, Fedora 40+) with a Go runtime fatal:

```
fatal error: non-Go code set up signal handler without SA_ONSTACK flag
```

Root cause: WebKitGTK's JSC installs `SIGSEGV` handlers without `SA_ONSTACK`, which Go's runtime refuses to tolerate. Wails 2.12's `g_idle_add` mitigation runs before JSC installs its handlers (JSC installs them lazily on first JS context creation), so it does not catch this case. Full analysis, reproducer, bisect, and Wails cross-refs in nebari-dev/nebi#350.

Bisected to commit nebari-dev/nebi@1546d97, first shipped in v0.10.5 — v0.10.4 is the last known-good release. Verified locally that `pixi global install nebi==0.10.4 && nebi-desktop` runs cleanly on the same affected host.

### Why include the umbrella `nebi` too

The `nebi` package pins `nebi-desktop ==${{ version }}` in its `run` requirements (see [recipe.yaml](https://github.com/conda-forge/nebi-feedstock/blob/main/recipe/recipe.yaml)). If only `nebi-desktop` were marked broken on linux-64, `nebi` on linux-64 would still resolve and then fail to install with a confusing dep error. Marking `nebi` directly gives the solver a clean miss so it falls back to 0.10.4.

### Why not other arches / not `nebi-cli`

- `nebi-cli` does not link WebKitGTK and is unaffected; Linux CLI users can continue to `pixi global install nebi-cli` on any version.
- macOS uses WKWebView and Windows uses WebView2 — neither hits this WebKitGTK code path.

### Forward path

The fix (a Linux-only cgo patch that periodically re-applies `SA_ONSTACK`, ~25 lines) will ship in a new release, **0.11.1**, which the feedstock will build as a new artifact. These older 0.10.5 / 0.11 builds remain permanently broken — there is no relabel plan.

### Maintainer ack

Feedstock maintainers per `recipe.yaml`: @viniciusdc, @Adam-D-Lewis. I am @Adam-D-Lewis and concur with this request.