### PR TITLE
Reset sweet-chem-o-mine feedstock token

### DIFF
--- a/requests/sweet-chem-o-mine-token-reset.yml
+++ b/requests/sweet-chem-o-mine-token-reset.yml
@@ -1,0 +1,3 @@
+action: token_reset
+feedstocks:
+- sweet-chem-o-mine


### PR DESCRIPTION
Requesting a token reset for `sweet-chem-o-mine-feedstock`.

The initial feedstock build produced `noarch/sweet-chem-o-mine-0.2.0-pyhc364b38_0.conda`, but upload/copy from `cf-staging` to `conda-forge` failed with `invalid feedstock token` / HTTP 403.

Related issue: https://github.com/conda-forge/sweet-chem-o-mine-feedstock/issues/1
Failed run: https://github.com/conda-forge/sweet-chem-o-mine-feedstock/actions/runs/26512919399