### PR TITLE
add `python-liteparse` to `liteparse`

### DIFF
--- a/requests/example-add-feedstock-output-liteparse.yml
+++ b/requests/example-add-feedstock-output-liteparse.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+    liteparse:
+        - python-liteparse


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->

`liteparse` was re-written in rust (yay) and now exposes native python bindings in addition to the CLI. I'm rebuilding it here: https://github.com/conda-forge/liteparse-feedstock/pull/14/.

@conda-forge/liteparse (me)

One Q: Is this `-split` naming prefered?

https://github.com/moritzwilksch/liteparse-feedstock/blob/c3eabd78b1b2a8ed95d188a5e1161e4afb2eba37/recipe/recipe.yaml#L9