### PR TITLE
adds new outputs for oiio/ocio

### DIFF
--- a/requests/openimageio-add-outputs.yml
+++ b/requests/openimageio-add-outputs.yml
@@ -1,0 +1,9 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  openimageio:
+    - libopencolorio
+    - py-opencolorio
+    - libopenimageio
+    - openimageio-tools
+    - opencolorio-tools
+    - opencolorio


### PR DESCRIPTION
This adds request for the new outputs introduced by conda-forge/openimageio-feedstock#138. That PR:
- adds OpenColorIO (required for OpenImageIO 3.X)
- splits OpenImageIO and OpenColorIO-related in multiple outputs in the same feedstock to handle the OpenImageIO/OpenColorIO integration and dependency cycle (ocio tools needs oiio lib that itself needs ocio lib) and have possiblity for lower size dependencies.

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
