### PR TITLE
Extend scikit-learn-intelex feedstock for gpu package

### DIFF
--- a/requests/add-scikit-learn-intelex-output-scikit-learn-intelex-gpu.yaml
+++ b/requests/add-scikit-learn-intelex-output-scikit-learn-intelex-gpu.yaml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  scikit-learn-intelex:
+    - scikit-learn-intelex-gpu


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

Adds entry `scikit-learn-intelex-gpu` to this feedstock:
https://github.com/conda-forge/scikit-learn-intelex-feedstock

This is because the library is being split into different packages for CPU and GPU, which will both be produced from the same source code and recipe.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->

@conda-forge/scikit-learn-intelex
