### PR TITLE
Request python bindings outputs added to roboplan-feedstock

### DIFF
--- a/requests/roboplan.yaml
+++ b/requests/roboplan.yaml
@@ -2,7 +2,6 @@ action: add_feedstock_output
 feedstock_to_output_mapping:
   roboplan:
     - roboplan-example-models-python
-    - roboplan-python
     - roboplan-oink-python
     - roboplan-rrt-python
     - roboplan-simple-ik-python

--- a/requests/roboplan.yaml
+++ b/requests/roboplan.yaml
@@ -1,0 +1,9 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  roboplan:
+    - roboplan-example-models-python
+    - roboplan-python
+    - roboplan-oink-python
+    - roboplan-rrt-python
+    - roboplan-simple-ik-python
+    - roboplan-toppra-python


### PR DESCRIPTION
These new outputs are being added to `roboplan-feedstock` because the way that Python bindings are generated is switching from one monolithic output (`roboplan-python`) to per-package Python binding outputs.

So for example, the `roboplan-simple-ik` package has both a C++ only library `libroboplan-simple-ik` and a Python bindings output `roboplan-simple-ik-python`.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
