### PR TITLE
token reset for qt-main

### DIFF
--- a/requests/qt-main.yml
+++ b/requests/qt-main.yml
@@ -1,0 +1,3 @@
+action: token_reset
+feedstocks:
+- qt-main


### PR DESCRIPTION
After merging https://github.com/conda-forge/qt-main-feedstock/pull/405, we get successful builds for linux on GHA, but then the upload fails à la:
```
Failed to upload due to Command '['anaconda', '--quiet', '--show-traceback', '-t', '/tmp/tmpur4ueokt/binstar.token', 'upload', '/home/conda/feedstock_root/build_artifacts/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda', '--user=cf-staging', '--channel=main', '--force-metadata-update']' returned non-zero exit status 1.. Trying again in 87.96388244628906 seconds
Using STAGING_BINSTAR_TOKEN for anaconda.org uploads to cf-staging.
Unauthorized: ('Authorization token is no longer valid', 401)
```

Reset the tokens.