### PR TITLE
add libpower-grid-model to power-grid-model feedstock

### DIFF
--- a/requests/add-libpower-grid-model-output-to-feedstock.yml
+++ b/requests/add-libpower-grid-model-output-to-feedstock.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  power-grid-model:
+    - libpower-grid-model


### PR DESCRIPTION
We would like to split the package output of feedstock `power-grid-model` into two:

* `libpower-grid-model`: the new name for native shared library
* `power-grid-model`: the current name will be used as the python package depending on `libpower-grid-model`.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/power-grid-model
ping @conda-forge/core 

