### PR TITLE
Add geowombat-dl, geowombat-detect, geowombat-sam outputs to geowombat-feedstock

### DIFF
--- a/requests/geowombat-add-outputs.yml
+++ b/requests/geowombat-add-outputs.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  geowombat:
+    - geowombat-dl
+    - geowombat-detect
+    - geowombat-sam


### PR DESCRIPTION
ping @conda-forge/geowombat

Adds three new sub-package outputs to geowombat-feedstock:

- `geowombat-dl` — deep learning extras (pytorch, torchgeo, segmentation-models-pytorch)
- `geowombat-detect` — object detection (ultralytics, torchmetrics, pycocotools, py-opencv<4.12)
- `geowombat-sam` — Segment Anything Model wrapper

These correspond to the `dl`, `detect`, and `sam` optional-dependency groups in geowombat's pyproject.toml. Required for conda-forge/geowombat-feedstock#126 to pass output validation. I'm an existing recipe-maintainer on the geowombat feedstock.