### PR TITLE
FIX: Add fastbdt-double-weight output

### DIFF
--- a/requests/add-fastbdt-double-weight-output.yml
+++ b/requests/add-fastbdt-double-weight-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  fastbdt:
+    - fastbdt-double-weight


### PR DESCRIPTION
* Add `fastbdt-double-weight` output for the `fastbdt` feedstock. In https://github.com/conda-forge/staged-recipes/pull/33516 the `fastbdt-double-weight` output was intended to be added as a metapackage for the fastbdt build variant `use_double_weight == OFF`. This output was not apparently not picked up in the mapping and so needs to be manually added in this PR.
   - c.f. https://github.com/conda-forge/fastbdt-feedstock
   - cc @conda-forge/fastbdt

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s) @conda-forge/fastbdt
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
