### PR TITLE
allow riscv64 outputs for ctng-compilers-activation feedstock

### DIFF
--- a/requests/ctng-compiler-activation.yaml
+++ b/requests/ctng-compiler-activation.yaml
@@ -5,4 +5,3 @@ feedstock_to_output_mapping:
     - gcc_linux-riscv64
     - gcc_bootstrap_linux-riscv64
     - gfortran_linux-riscv64
-  

--- a/requests/ctng-compiler-activation.yaml
+++ b/requests/ctng-compiler-activation.yaml
@@ -1,0 +1,8 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  ctng-compiler-activation:
+    - gxx_linux-riscv64
+    - gcc_linux-riscv64
+    - gcc_bootstrap_linux-riscv64
+    - gfortran_linux-riscv64
+  


### PR DESCRIPTION
## Template selection

Please go to the "Preview" tab and select the appropriate template:

* [I want to mark a package as broken (or not broken)](?expand=1&template=broken.md)
* [I want to archive a feedstock](?expand=1&template=archive.md)
* [I want to request (or revoke) access to an opt-in CI resource](?expand=1&template=ci-resource.md)
* [I want to copy an artifact following CFEP-3](?expand=1&template=cfep-3.md)
* [I want to add a package output to a feedstock](?expand=1&template=add-feedstock-output.md)
