### PR TITLE
Mark smmap 6.0.0 as broken

### DIFF
--- a/requests/smmap-broken.yml
+++ b/requests/smmap-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/smmap-6.0.0-pyhd8ed1ab_3.conda


### PR DESCRIPTION
## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

smmap 6.0.0 has been yanked upstream.
ref: https://pypi.org/project/smmap/6.0.0/

ping @conda-forge/smmap
