### PR TITLE
Add libxrootd, libxrootd-devel, python-xrootd and xrootd-cli outputs

### DIFF
--- a/requests/add-xrootd-outputs.yml
+++ b/requests/add-xrootd-outputs.yml
@@ -1,0 +1,7 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  xrootd:
+    - libxrootd
+    - libxrootd-devel
+    - python-xrootd
+    - xrootd-cli


### PR DESCRIPTION
As part of XRootD 6 (which is an ABI break) I'm splitting the package into CLI/devel/python bindings to reduce the number of builds and generally make things cleaner.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
