### PR TITLE
Mark pydantic-extra-types 2.11.2 as broken

### DIFF
--- a/requests/pydantic-extra-types-broken.yaml
+++ b/requests/pydantic-extra-types-broken.yaml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/pydantic-extra-types-2.11.2-pyhcf101f3_0.conda


### PR DESCRIPTION
## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

pydantic-extra-types 2.11.2  has been yanked upstream.
ref: https://pypi.org/project/pydantic-extra-types/2.11.2/

ping @conda-forge/pydantic-extra-types