### PR TITLE
mark flask-cors 6.0.3_0 broken

### DIFF
--- a/requests/broken-flask-cors-6.0.3_0.yml
+++ b/requests/broken-flask-cors-6.0.3_0.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+  - noarch/flask-cors-6.0.3-pyhcf101f3_0.conda


### PR DESCRIPTION
## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* You can use `pixi run find-name {matchspec}` to get a list of filenames matching given spec.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

over on @conda-forge/flask-cors:
- https://github.com/conda-forge/flask-cors-feedstock/pull/22 was merged and shipped `6.0.2_0`
  - this would fail all downstream `pip check` and `importlib.metadata.version` checks,, as it thinks its version is `0.0.0`
- https://github.com/conda-forge/flask-cors-feedstock/pull/23 shipped `6.0.2_1`
  - added `setuptools-scm` and several tests to avoid this kind of problem in the future