### PR TITLE
Add soundfile output to pysoundfile feedstock

### DIFF
--- a/requests/add-soundfile-output.yml
+++ b/requests/add-soundfile-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  pysoundfile:
+    - soundfile


### PR DESCRIPTION
`action: add_feedstock_output` — allow the `pysoundfile` feedstock to publish the `soundfile` output.

The upstream project was renamed `pysoundfile` → `soundfile`. The feedstock (conda-forge/pysoundfile-feedstock) is moving to build under the canonical `soundfile` name while keeping a `pysoundfile` transition metapackage. The `soundfile` output name is currently unregistered/unused.

Related: conda-forge/pysoundfile-feedstock#30 (rename PR, blocked on output validation) and #23.