### PR TITLE
Add pytrilinos to trilinos outputs

### DIFF
--- a/requests/add-feedstock-output.yml
+++ b/requests/add-feedstock-output.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  trilinos:
+    - trilinos
+    - "pytrilinos*"

--- a/requests/add-feedstock-output.yml
+++ b/requests/add-feedstock-output.yml
@@ -1,4 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
   trilinos:
-    - "pytrilinos*"
+    - pytrilinos

--- a/requests/add-feedstock-output.yml
+++ b/requests/add-feedstock-output.yml
@@ -1,5 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
   trilinos:
-    - trilinos
     - "pytrilinos*"


### PR DESCRIPTION
Instead of essentially building all of the trilinos pacakges twice, suggest archiving the current pytrilinos feedstock and adding a pytrilinos* output to the trilinos feedstock. Glob form of pytrilinos is used to help distinguish between pytrilinos and pytrilinos2, the latter of which is the more modern package.

ping @conda-forge/trilinos 

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
