### PR TITLE
Archive pytrilinos feedstock

### DIFF
--- a/requests/archive-pytrilinos.yml
+++ b/requests/archive-pytrilinos.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - pytrilinos


### PR DESCRIPTION
The trilinos feedstock will produce both trilinos and pytrilinos* outputs, so a standalone pytrilinos feedstock is no longer needed. (Ref #2136)

Issue in feedstock: conda-forge/pytrilinos-feedstock#66

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

pint @conda-forge/pytrilinos 

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to archive a `foo` feedstock.

  ping @conda-forge/foo

-->
