### PR TITLE
add digital-rivers-all

### DIFF
--- a/requests/add-digital-rivers-output-all.yml
+++ b/requests/add-digital-rivers-output-all.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  digital-rivers:
+    - digital-rivers-all


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

This PR registers `digital-rivers-all` as an additional output of the existing `digital-rivers-feedstock`.
`digital-rivers-all` is a metapackage matching the `pip install "digital-rivers[all]"` extra, which pulls
`digital-rivers[viz,distributed]`. Registering this feedstock-output mapping authorizes the feedstock to
publish the new output (otherwise `validate_recipe_outputs` rejects it).

Feedstock: https://github.com/conda-forge/digital-rivers-feedstock

ping @conda-forge/digital-rivers
