### PR TITLE
add digitalearth-3d

### DIFF
--- a/requests/add-digitalearth-output-3d.yml
+++ b/requests/add-digitalearth-output-3d.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  digitalearth:
+    - digitalearth-3d


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

This PR registers `digitalearth-3d` as an additional output of the existing `digitalearth-feedstock`.
`digitalearth-3d` is a metapackage matching the `pip install "digitalearth[3d]"` extra, which pulls the
PyVista-based true-3D tier (pyvista, trame, trame-vtk, trame-vuetify, geovista, imageio, imageio-ffmpeg).
Registering this feedstock-output mapping authorizes the feedstock to publish the new output (otherwise
`validate_recipe_outputs` rejects it).

Feedstock: https://github.com/conda-forge/digitalearth-feedstock

ping @conda-forge/digitalearth