### PR TITLE
chore: add pyaedt outputs

### DIFF
--- a/requests/pyaedt-add-output.yml
+++ b/requests/pyaedt-add-output.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  pyaedt:
+    - pyaedt-base
+    - pyaedt-dotnet
+    - pyaedt-graphics


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

This PR registers `pyaedt-base`, `pyaedt-dotnet` and `pyaedt-graphics` as additional outputs of the existing [pyaedt-feedstock](https://github.com/conda-forge/pyaedt-feedstock). The outputs provide a way to retrieve `pyaedt` with different flavors matching the optional targets available on PyPI.

Associated PR in `pyaedt-feedstock`: https://github.com/conda-forge/pyaedt-feedstock/pull/173

Thanks in advance for your help !