### PR TITLE
mark `conda-smithy-2026.6.14 *_0` as broken on unix

### DIFF
--- a/requests/smithy.yml
+++ b/requests/smithy.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/conda-smithy-2026.6.14-unix_pyh9ac5cc3_0.conda


### PR DESCRIPTION
There was an issue with the release from https://github.com/conda-forge/conda-smithy-feedstock/pull/391 (already superseded by https://github.com/conda-forge/conda-smithy-feedstock/pull/397). For good measure, mark the old build as broken. The windows side of things works fine (the relevant permission bits that caused issues don't survive on windows).