### PR TITLE
archive old branches for singlejar & bazel

### DIFF
--- a/requests/bazel.yml
+++ b/requests/bazel.yml
@@ -1,0 +1,15 @@
+action: archive_branch
+feedstocks:
+  bazel:
+    - 2.0
+    - 3.1.x
+    - 4.2.1
+    - 4.2.x
+    - 6.1.x
+    - 7.4.1
+  singlejar:
+    - 5.2.x
+    - 6.3.2
+    - 6.1.x
+    - 7.2.1
+    - 7.4.1


### PR DESCRIPTION
Clean up some ancient branches, keep only `5.x`, `6.x`, `7.x`, `8.x`. If necessary, these branches can be restored from the tag they get parked in.

CC @conda-forge/bazel @conda-forge/singlejar 