### PR TITLE
Mark broken: lightly 1.15.21 / 1.15.22

### DIFF
--- a/requests/mark-broken-lightly-1.15.yml
+++ b/requests/mark-broken-lightly-1.15.yml
@@ -1,0 +1,4 @@
+action: broken
+packages:
+- noarch/lightly-1.15.21-pyhd8ed1ab_0.conda
+- noarch/lightly-1.15.22-pyhd8ed1ab_0.conda


### PR DESCRIPTION
These two `lightly` builds came from typoed GitHub release tags (`v1.15.x` instead of `v1.5.x`). The actual Python package versions in the corresponding upstream releases are `1.5.21` and `1.5.22`.

Because `1.15.x` sorts higher than the valid `1.5.x` line, these artifacts currently shadow the real latest `lightly` release on conda-forge. Please mark them broken so default conda resolution no longer selects them.

The feedstock has since been corrected to source from the PyPI sdist, and valid `1.5.22+` packages are available.
