### PR TITLE
Add collier-devel output

### DIFF
--- a/requests/add-collier-devel-output.yml
+++ b/requests/add-collier-devel-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  collier:
+    - collier-devel


### PR DESCRIPTION
* Add `collier-devel` output to https://github.com/conda-forge/collier-feedstock/ to distribute internal Fortran modules that some downstream packages need to build interface extensions to COLLIER. (e.g. https://gitlab.com/openloops/OpenLoops) Required for https://github.com/conda-forge/collier-feedstock/pull/8.

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
   - I am a member of @conda-forge/collier
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
