### PR TITLE
Unpin conda-smithy semver ranges

### DIFF
--- a/scripts/create_feedstocks
+++ b/scripts/create_feedstocks
@@ -39,7 +39,7 @@ source ~/Miniforge3/bin/activate
 
 conda install --yes --quiet \
   conda-forge-ci-setup=4.* \
-  "conda-smithy>=3.38.0,<4.0.0a0" \
+  "conda-smithy>=2026 \
   conda-forge-pinning \
   "conda-build>=24.3" \
   "gitpython>=3.0.8,<3.1.20" \


### PR DESCRIPTION
This bit was not updated when conda-smithy changed to calver releases, so we are hitting CLI errors for unknown flags.