### PR TITLE
unarchive mistralai

### DIFF
--- a/requests/mistralai.yml
+++ b/requests/mistralai.yml
@@ -1,0 +1,3 @@
+action: unarchive
+feedstocks:
+  - mistralai


### PR DESCRIPTION
Hi,

Based on the discussion in [Zulip](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/mistralai.20package.20archived) and the fact that the advisory is considered [handled](https://docs.mistral.ai/resources/security-advisories#tanstack-supply-chain-attack) could the `mistralai` repository be unarchive please ? 
