### PR TITLE
Add photo-tagger-gui output to photo-tagger feedstock

### DIFF
--- a/requests/add-photo-tagger-gui-output.yml
+++ b/requests/add-photo-tagger-gui-output.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # New optional GUI metapackage output added to the photo-tagger feedstock.
+  # See https://github.com/conda-forge/photo-tagger-feedstock/pull/3
+  photo-tagger:
+    - photo-tagger-gui


### PR DESCRIPTION
Registers the new output `photo-tagger-gui` to the `photo-tagger` feedstock.

photo-tagger 0.3.0 adds an optional PySide6 desktop GUI. Since conda has no pip-style extras, the feedstock exposes it as a separate `photo-tagger-gui` metapackage output (pins the exact `photo-tagger` build + `pyside6`). The output-validation check fails until this name is registered.

- Feedstock PR adding the output: conda-forge/photo-tagger-feedstock#3
- `photo-tagger-gui` is a new, unclaimed name (no existing feedstock produces it).