### PR TITLE
Add new crewai packages to feeedstock output

### DIFF
--- a/requests/add-crewai-suite-feedstock-output.yml
+++ b/requests/add-crewai-suite-feedstock-output.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # crewai 1.14.7 includes two new packages, crewai-core and crewai-cli.
+  # ref: https://github.com/conda-forge/crewai-suite-feedstock/pull/4
+  crewai-suite:
+    - "crewai*"

--- a/requests/add-crewai-suite-feedstock-output.yml
+++ b/requests/add-crewai-suite-feedstock-output.yml
@@ -3,4 +3,5 @@ feedstock_to_output_mapping:
   # crewai 1.14.7 includes two new packages, crewai-core and crewai-cli.
   # ref: https://github.com/conda-forge/crewai-suite-feedstock/pull/4
   crewai-suite:
-    - "crewai*"
+    - crewai-core
+    - crewai-cli


### PR DESCRIPTION
The latest version of crewai adds the `crewai-core` and `crewai-cli` packages.

ref: https://github.com/conda-forge/crewai-suite-feedstock/pull/4
ref: https://github.com/crewAIInc/crewAI/tree/1.14.7/lib

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Added a small description of why the output is being added.


