### PR TITLE
Register apple-container output

### DIFF
--- a/requests/apple-container.yml
+++ b/requests/apple-container.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  apple-container:
+    - apple-container


### PR DESCRIPTION
This is necessary because the feedstock had empty ci_support on registration (osx-arm64 only)