### PR TITLE
Add pymomentum-core output to momentum feedstock

### DIFF
--- a/requests/add-pymomentum-core-output.yml
+++ b/requests/add-pymomentum-core-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  momentum:
+    - pymomentum-core


### PR DESCRIPTION
This request adds the `pymomentum-core` output to the existing `momentum` feedstock.

Context: conda-forge/momentum-feedstock#301 mirrors the upstream PyPI split introduced in facebookresearch/momentum#1483 and followed up in facebookresearch/momentum#1523. The new conda output is intended to provide the core PyMomentum modules without the Torch C++ extension modules, while `pymomentum-cpu` and `pymomentum-gpu` remain the full packages.

Current output validation failure: https://github.com/conda-forge/momentum-feedstock/actions/runs/28132597670/job/83312145519

That job builds successfully, then fails the feedstock output validation step because `linux-64/pymomentum-core-0.1.111-core_py312_he0759dc_2.conda` is not yet allowed for `momentum-feedstock`.

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
    - I am a member of @conda-forge/momentum.
  * [x] Added a small description of why the output is being added.