### PR TITLE
Request `roboplan-cartesian-planning` outputs added to `roboplan-feedstock`

### DIFF
--- a/requests/roboplan.yaml
+++ b/requests/roboplan.yaml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  roboplan:
+    - libroboplan-cartesian-planning
+    - roboplan-cartesian-planning-python


### PR DESCRIPTION
There was a new package added to the https://github.com/open-planning/roboplan repo, so we need these additional outputs to the feedstock added (https://github.com/conda-forge/roboplan-feedstock) -- thanks!

I am an owner of that feedstock so consider this a self-ping :)

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
