### PR TITLE
add smart_open output smart-open-with-lz4

### DIFF
--- a/requests/add-smart-open-with-lz4.yml
+++ b/requests/add-smart-open-with-lz4.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  smart_open:
+    - smart-open-with-lz4


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/smart_open 

On https://github.com/conda-forge/smart_open-feedstock/pull/78, there is a new output with a dependency on `lz4` to match the [upstream](https://raw.githubusercontent.com/piskvorky/smart_open/refs/tags/v7.7.1/pyproject.toml).