### PR TITLE
Request larger runners for graph-tool

### DIFF
--- a/requests/graph-tool.yml
+++ b/requests/graph-tool.yml
@@ -1,0 +1,4 @@
+action: blacksmith
+feedstocks:
+  - graph-tool
+revoke: false


### PR DESCRIPTION
## Checklist:

* [x] I want to request (or revoke) access to an opt-in CI resource:
* [x] Pinged the relevant feedstock team(s)
* [x] Added a small description explaining why access is needed

ping @conda-forge/graph-tool 

graph-tool is a high-performance and comprehensive python library for network analysis written in  C++, relying heavily on template meta-programming. It has been downloaded more than 2M times from conda-forge alone.

The current development version is systematically exceeding the 6 hour limit of the standard runners, using all available threads, and making the most of available compile time optimizations, such as LTO. 

Some individual compilation units also exceed the memory available, causing the system to swap, and slow down the build.

As the library grows, I have the impression that it will soon be impossible to build it on the current runners, and therefore I'm requesting access to the larger ones.

