### PR TITLE
Move to Python 3.11, bump lower bound for conda-smithy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - pygithub
   - pydantic
   - cirun
-  - conda-smithy >=3.30.1
+  - conda-smithy >=2026
   - conda-forge-metadata >=0.9.1
   - ruamel.yaml
   - conda-build >=25.3.1

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - anaconda-client
-  - python =3.10
+  - python =3.11
   - requests
   - pygithub
   - pydantic


### PR DESCRIPTION
Fix `--with-depot` error. By pinning Python 3.10 we are only getting 3.x on `main`; bump to 3.11.