### PR TITLE
Add stimcirq output for stim-split

### DIFF
--- a/requests/stimcirq-output.yml
+++ b/requests/stimcirq-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  stim-split:
+    - stimcirq


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/stim-split

Adding `stimcirq` for `conda-forge/stim-split-feedstock`. `conda-forge/stim-split-feedstock#8` adds it as a noarch Python output from upstream `glue/cirq`, and Linux upload validation is blocked until `stimcirq` is registered for this feedstock.