### PR TITLE
Add jupytergis-tiler output to jupytergis-packages-feedstock

### DIFF
--- a/requests/add-jupytergis-tiler-output.yml
+++ b/requests/add-jupytergis-tiler-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  jupytergis:
+    - jupytergis-tiler

--- a/requests/add-jupytergis-tiler-output.yml
+++ b/requests/add-jupytergis-tiler-output.yml
@@ -1,4 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
-  jupytergis:
+  jupytergis-packages:
     - jupytergis-tiler


### PR DESCRIPTION
This is an optional dependency group of jupytergis, specified in PyPI as `jupytergis[tiler]`.

Looking forward to CEP44 ;)

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
ping @conda-forge/jupytergis-packages