### PR TITLE
Revert "remove graph-tool.yml"

### DIFF
--- a/requests/graph-tool.yml
+++ b/requests/graph-tool.yml
@@ -1,0 +1,4 @@
+action: namespace
+feedstocks:
+- graph-tool
+revoke: false


### PR DESCRIPTION
The request to add blacksmith/namespace has been failing with
```
  File "/home/runner/miniconda3/envs/cf/lib/python3.12/site-packages/conda_smithy/ci_register.py", line 568, in enable_namespace_app
    github.configure_github_app(org, project, app)
  File "/home/runner/miniconda3/envs/cf/lib/python3.12/site-packages/conda_smithy/github.py", line 617, in configure_github_app
    repo: github.Repository = org.get_repo(repo)
                              ^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/cf/lib/python3.12/site-packages/github/Organization.py", line 1355, in get_repo
    return github.Repository.Repository(self._requester, url=url, accept=Consts.repoVisibilityPreview)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/cf/lib/python3.12/site-packages/github/GithubObject.py", line 570, in __init__
    self.complete()
  File "/home/runner/miniconda3/envs/cf/lib/python3.12/site-packages/github/GithubObject.py", line 615, in complete
    self._completeIfNeeded()
  File "/home/runner/miniconda3/envs/cf/lib/python3.12/site-packages/github/GithubObject.py", line 624, in _completeIfNeeded
    self._complete()
  File "/home/runner/miniconda3/envs/cf/lib/python3.12/site-packages/github/GithubObject.py", line 629, in _complete
    headers, data = self._requester.requestJsonAndCheck(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/cf/lib/python3.12/site-packages/github/Requester.py", line 628, in requestJsonAndCheck
    *self.__check(
     ^^^^^^^^^^^^^
  File "/home/runner/miniconda3/envs/cf/lib/python3.12/site-packages/github/Requester.py", line 867, in __check
    raise self.createException(status, responseHeaders, data)
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/repos/repos#get-a-repository", "status": "404"}
```

It was attempted in #2168, disabled due to [spiralling](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/Admin.20request.20bot.20looping/with/606789815) commits in https://github.com/conda-forge/admin-requests/commit/5574a9ef80eeb1604e3531a5e4f86c54c7ca053c (which caused linter failures though), reattempted with https://github.com/conda-forge/admin-requests/commit/593e5b579ea02264cf995d4761b22d5fc76be1f0 in #2175, switched from blacksmith to namespace in #2172, and finally deleted entirely in 25d81c98c13d2083b0f2378d2e71958c83cc6a6d.

Since this happens during the `__check` phase, it should theoretically also appear in a PR; fingers crossed 🤞 