### PR TITLE
Add `howardhinnant_date-static` to `howardhinnant_date-feedstock`

### DIFF
--- a/requests/howardhinnant_date-static_output.yaml
+++ b/requests/howardhinnant_date-static_output.yaml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  howardhinnant_date:
+    - howardhinnant_date-static


### PR DESCRIPTION
Add `howardhinnant_date-static` output name for static `date` library build in addition to the existing shared library shipped by `howardhinnant_date`.

See https://github.com/conda-forge/howardhinnant_date-feedstock/pull/21.

cc @conda-forge/howardhinnant_date

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.


