### PR TITLE
Mark Firecrown 1.15.0 builds as broken

### DIFF
--- a/requests/firecrown-1.15.0.yml
+++ b/requests/firecrown-1.15.0.yml
@@ -1,0 +1,19 @@
+action: broken
+
+packages:
+  - linux-64/firecrown-1.15.0-py311h38be061_0.conda
+  - linux-64/firecrown-1.15.0-py312h7900ff3_0.conda
+  - linux-64/firecrown-1.15.0-py313h78bf25f_0.conda
+  - linux-64/firecrown-1.15.0-py314hdafbbf9_0.conda
+  - linux-aarch64/firecrown-1.15.0-py311hec3470c_0.conda
+  - linux-aarch64/firecrown-1.15.0-py312h996f985_0.conda
+  - linux-aarch64/firecrown-1.15.0-py313hd81a959_0.conda
+  - linux-aarch64/firecrown-1.15.0-py314h28a4750_0.conda
+  - osx-64/firecrown-1.15.0-py311h6eed73b_0.conda
+  - osx-64/firecrown-1.15.0-py312hb401068_0.conda
+  - osx-64/firecrown-1.15.0-py313habf4b1d_0.conda
+  - osx-64/firecrown-1.15.0-py314hee6578b_0.conda
+  - osx-arm64/firecrown-1.15.0-py311h267d04e_0.conda
+  - osx-arm64/firecrown-1.15.0-py312h81bd7bf_0.conda
+  - osx-arm64/firecrown-1.15.0-py313h8f79df9_0.conda
+  - osx-arm64/firecrown-1.15.0-py314h4dc9dd8_0.conda


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

The upstream `firecrown` 1.15.0 `_0` builds were produced with an incorrect package version (`0.0.0`) due to a `setuptools_scm` configuration issue during the build. The packages have been rebuilt as `_1` with the correct package version (`1.15.0`). These `_0` builds should be marked as broken to prevent users from installing distributions that report an incorrect version.

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* You can use `pixi run find-name {matchspec}` to get a list of filenames matching given spec.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.

## Checklist:

  * [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.