### PR TITLE
Request larger runners for pinocchio

### DIFF
--- a/requests/pinocchio.yml
+++ b/requests/pinocchio.yml
@@ -1,0 +1,4 @@
+action: namespace
+feedstocks:
+  - pinocchio
+revoke: false


### PR DESCRIPTION
## Checklist:

* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description explaining why access is needed

ping @conda-forge/pinocchio 

Pinocchio  build time can be very long and consume a lot of memory.

On the current build we have memory and build time issues we fixed by:
- Not activating all features
- [Limiting parallel build](https://github.com/conda-forge/pinocchio-feedstock/blob/main/recipe/build_pinocchio_python.sh#L46)

Recently, we have tried to migrate to https://github.com/conda-forge/pinocchio-feedstock/pull/162. But the new build process build libpinocchio and all pinocchio-python binding sequentially, making us reach the 6h time limit.

Internally we plan to migrate to some more recent libraries to accelerate the build time, but it will be done on the long run.

Close #2127 

