### PR TITLE
Add new outputs to lerobot v0.6.0

### DIFF
--- a/requests/lerobot-0-6-0.yml
+++ b/requests/lerobot-0-6-0.yml
@@ -1,0 +1,7 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  lerobot:
+    - lerobot-viz
+    - lerobot-hardware
+    - lerobot-training
+    - lerobot-dataset


### PR DESCRIPTION
This PR requests adding the following outputs to the lerobot-feedstock allowlist, as per upstream 0.6.0 release:

- `lerobot-viz`
- `lerobot-training`
- `lerobot-dataset`
- `lerobot-hardware`

Related: https://github.com/conda-forge/lerobot-feedstock/pull/16

FYI @conda-forge/lerobot

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
