### PR TITLE
[plaid] add feedstock output: plaid-viewer

### DIFF
--- a/requests/add-feedstock-output.yml
+++ b/requests/add-feedstock-output.yml
@@ -1,3 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
-  - plaid: plaid-viewer
+  plaid:
+    - "plaid-viewer"

--- a/requests/add-feedstock-output.yml
+++ b/requests/add-feedstock-output.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  - plaid: plaid-viewer


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

This PR requests adding the "plaid-viewer" outputs to the plaid-feedstock allowlist, as per 1.0.0 release.

Related: https://github.com/conda-forge/plaid-feedstock/pull/42

Context: visualization tools have been developped in the plaid package, and we want the keep the core package with as few dependencies as possible.

ping @conda-forge/plaid

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.


<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
