### PR TITLE
add pyshacl output pyshacl-with-oxigraph

### DIFF
--- a/requests/add-pyshacl-output-with-oxigraph.yml
+++ b/requests/add-pyshacl-output-with-oxigraph.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  pyshacl:
+    - pyshacl-with-oxigraph


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

over on @conda-forge/pyshacl, https://github.com/conda-forge/pyshacl-feedstock/pull/65 adds a new output `-with-oxigraph` with a pin to match the [upstream `pyproject.toml`](https://github.com/RDFLib/pySHACL/compare/v0.31.0...v0.40.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R68-R70)  