### PR TITLE
Archive duplicate `coreapi` & `coreschema` feedstocks

### DIFF
--- a/examples/archive-coreapi.yml
+++ b/examples/archive-coreapi.yml
@@ -1,0 +1,4 @@
+action: archive
+feedstocks:
+  - coreapi
+  - coreschema


### PR DESCRIPTION

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to archive a `foo` feedstock.

  ping @conda-forge/foo

-->
They are duplicates to the earlier `python-coreapi` and `python-coreschema` feedstocks, respectively.  They do not have any reverse dependencies outside of themselves.

- https://github.com/conda-forge/coreapi-feedstock/issues/2
- https://github.com/conda-forge/coreschema-feedstock/issues/3

ping @conda-forge/coreapi @conda-forge/coreschema 