### PR TITLE
Add new output for xraylib

### DIFF
--- a/requests/add-xraylib-output.yml
+++ b/requests/add-xraylib-output.yml
@@ -1,0 +1,7 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  xraylib:
+    # C/C++/Fortran base package
+    - libxraylib
+    # Python package depending on libxraylib
+    - xraylib


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

Hi,

I have a PR that splits `xraylib` into two outputs:
1. `libxraylib` - the base C/C++/Fortran library
2. `xraylib` - the current output - the Python library (which uses `libxraylib`)

The PR is here: https://github.com/conda-forge/xraylib-feedstock/pull/62 
It's failing only on the output validation step, I believe.

Ping @conda-forge/xraylib 

## Checklist:

* [x] I want to add a package output to a feedstock: [xraylib](https://github.com/conda-forge/xraylib-feedstock/)
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
