### PR TITLE
Adding photutils-base

### DIFF
--- a/requests/photutils-base.yml
+++ b/requests/photutils-base.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  photutils:
+    - photutils
+    - photutils-base

--- a/requests/photutils-base.yml
+++ b/requests/photutils-base.yml
@@ -1,5 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
   photutils:
-    - photutils
     - photutils-base


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

We would like to add a `photutils-base` output that only pulls in the mandatory dependencies of photutils, while the currently existing `photutils` will keep pulling in optional dependencies, too. This would allow downstream users to opt out from being gridlocked into unresolvable dependency issues (we know about issues regarding rasterio, which is only an optional dependency).

Relevant feedstock PR is this one: https://github.com/conda-forge/photutils-feedstock/pull/64


## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
         request came from out users, and I'm opening this request as a member of the feedstock team (all the others support the idea as well)
  * [x] Added a small description of why the output is being added.


  cc @conda-forge/photutils


