### PR TITLE
Archive a number of gds-* feedstocks

### DIFF
--- a/requests/gds-archive.yml
+++ b/requests/gds-archive.yml
@@ -1,0 +1,8 @@
+action: archive
+feedstocks:
+  - gds-dmt
+  - gds-gui
+  - gds-lowlatency-tools
+  - gds-monitor-apps
+  - gds-swig
+  - igwn-lldd-lsmp


### PR DESCRIPTION
The LIGO Global Diagnostics System (GDS) is no longer supported, so many packages are now no longer required. This PR requests archiving a number of feedstocks at the end of the package chain, including one downstream project.

I am a maintainer of all feedstocks.

See the following issues:

- https://github.com/conda-forge/gds-dmt-feedstock/issues/21
- https://github.com/conda-forge/gds-gui-feedstock/issues/34
- https://github.com/conda-forge/gds-lowlatency-tools-feedstock/issues/5
- https://github.com/conda-forge/gds-monitor-apps-feedstock/issues/16
- https://github.com/conda-forge/gds-swig-feedstock/issues/22
- https://github.com/conda-forge/igwn-lldd-lsmp-feedstock/issues/7

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.