### PR TITLE
Request `roboplan-all` outputs added to `roboplan-feedstock`

### DIFF
--- a/requests/roboplan.yaml
+++ b/requests/roboplan.yaml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  roboplan:
+    - libroboplan-all
+    - roboplan-all-python


### PR DESCRIPTION
I'm requesting the addition of a few more outputs to this feedstock, which will be metapackages containing all the other outputs for convenience. See https://github.com/conda-forge/roboplan-feedstock/pull/17

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
