### PR TITLE
Add highspy-extras output to highspy

### DIFF
--- a/requests/add-highspy-output-extras.yml
+++ b/requests/add-highspy-output-extras.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  highspy:
+    - highspy-extras


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [X] Pinged the relevant feedstock team(s)
  * [X] Added a small description of why the output is being added.

ping @conda-forge/highspy
Adding highspy-extras as allowed output to highspy feedstock, they live in the same repository upstream. The change is made in this PR conda-forge/highspy-feedstock#32 as a followup to the PR conda-forge/staged-recipes#33388 by @galabovaa 