### PR TITLE
Mark fcgi2 2.4.7 build 1 on windows as broken

### DIFF
--- a/requests/fcgi2.yml
+++ b/requests/fcgi2.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+  - win-64/fcgi2-2.4.7-h477610d_1.conda


### PR DESCRIPTION
## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

reported at conda-forge/fcgi2-feedstock/issues/10

Something went wrong(tm) with the windows build after the v1 recipe migration.  The windows build only contains metadata.

ping @conda-forge/fcgi2 
