### PR TITLE
Do not push empty commits in main requests workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,3 +82,19 @@ jobs:
         run: |
           git pull
           git push
+
+      - name: raise issue if needed
+        if: steps.conversion_lock.outcome == 'success' && ! env.CI_SKIP && ! env.FAILING_FILENAMES_TO_RAISE
+        shell: bash -el {0}
+        run: |
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          for fn in $FAILING_FILENAMES_TO_RAISE; do  # env var maybe exported by __main__.py
+            title="Request $fn is failing"
+            # Only create issue if there are no open ones with the same title
+            if [[ "$(gh issue list --state open --search "\"$title\" in:title" --json number --jq 'length')" == "0" ]]; then
+              gh issue create \
+                --title "$title" \
+                --body "This request has been failing for more than 6 hours, please inspect logs at $RUN_URL" \
+                --label ci-error
+            fi
+          done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
         if: steps.conversion_lock.outcome == 'success'
         with:
           token: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
+          fetch-depth: 0  # needed for accurate creation timestamps while checking failing requests
 
       - name: fast finish
         if: ${{ steps.conversion_lock.outcome == 'success' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,8 @@ jobs:
       - name: raise issue if needed
         if: steps.conversion_lock.outcome == 'success' && ! env.CI_SKIP && env.FAILING_FILENAMES_TO_RAISE
         shell: bash -el {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           for fn in $FAILING_FILENAMES_TO_RAISE; do  # env var maybe exported by __main__.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
           git push
 
       - name: raise issue if needed
-        if: steps.conversion_lock.outcome == 'success' && ! env.CI_SKIP && ! env.FAILING_FILENAMES_TO_RAISE
+        if: steps.conversion_lock.outcome == 'success' && ! env.CI_SKIP && env.FAILING_FILENAMES_TO_RAISE
         shell: bash -el {0}
         run: |
           RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/conda_forge_admin_requests/__main__.py
+++ b/conda_forge_admin_requests/__main__.py
@@ -92,12 +92,11 @@ def run():
                     ]
                 )
             else:
-                # How old is this failing file? Raise issue after 6h
+                # How old is this failing file? Raise issue after 6h of last modification
                 added_at = subprocess.check_output(
                     [
                         "git",
                         "log",
-                        "--diff-filter=A",
                         "-1",
                         "--format=%aI",
                         "--",

--- a/conda_forge_admin_requests/__main__.py
+++ b/conda_forge_admin_requests/__main__.py
@@ -107,6 +107,7 @@ def run():
                 ).strip()
                 if added_at:
                     added_at_dt = datetime.fromisoformat(added_at)
+                    # Keep this magic number in sync with the issue message in GHA's main.yml
                     if datetime.now(tz=timezone.utc) - added_at_dt > timedelta(hours=6):
                         failing_filenames_to_raise.append(filename)
                 else:

--- a/conda_forge_admin_requests/__main__.py
+++ b/conda_forge_admin_requests/__main__.py
@@ -79,15 +79,15 @@ def run():
             with open(filename, "w") as fp:
                 yaml.dump(try_again, fp)
             subprocess.check_call(["git", "add", filename])
-            subprocess.check_call(
-                [
-                    "git",
-                    "commit",
-                    "--allow-empty",
-                    "-m",
-                    f"Keeping {filename} after failed {action}",
-                ]
-            )
+            if subprocess.call(["git", "diff", "--cached", "--quiet"]) != 0:
+                subprocess.check_call(
+                    [
+                        "git",
+                        "commit",
+                        "-m",
+                        f"Keeping {filename} after failed {action}",
+                    ]
+                )
         else:
             subprocess.check_call(["git", "rm", filename])
             subprocess.check_call(

--- a/conda_forge_admin_requests/__main__.py
+++ b/conda_forge_admin_requests/__main__.py
@@ -2,6 +2,7 @@ import glob
 import os
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 
 import yaml
 
@@ -61,6 +62,7 @@ def check():
 def run():
     filenames = _get_task_files()
 
+    failing_filenames_to_raise = []
     for filename in filenames:
         with open(filename) as f:
             request = yaml.safe_load(f)
@@ -80,6 +82,7 @@ def run():
                 yaml.dump(try_again, fp)
             subprocess.check_call(["git", "add", filename])
             if subprocess.call(["git", "diff", "--cached", "--quiet"]) != 0:
+                # Only commit if there are changes
                 subprocess.check_call(
                     [
                         "git",
@@ -88,10 +91,34 @@ def run():
                         f"Keeping {filename} after failed {action}",
                     ]
                 )
+            else:
+                # How old is this failing file? Raise issue after 6h
+                added_at = datetime.fromisoformat(
+                    subprocess.check_output(
+                        [
+                            "git",
+                            "log",
+                            "--diff-filter=A",
+                            "-1",
+                            "--format=%aI",
+                            "--",
+                            filename,
+                        ],
+                        text=True,
+                    ).strip()
+                )
+                # Keep the timedelta value aligned with the issue message in `main.yml`
+                if datetime.now(tz=timezone.utc) - added_at > timedelta(hours=6):
+                    failing_filenames_to_raise.append(filename)
         else:
             subprocess.check_call(["git", "rm", filename])
             subprocess.check_call(
                 ["git", "commit", "-m", f"Remove {filename} after {action}"]
+            )
+    if failing_filenames_to_raise:
+        with open(os.environ["GITHUB_ENV"], "a") as f:
+            f.write(
+                f"FAILING_FILENAMES_TO_RAISE={' '.join(failing_filenames_to_raise)}\n"
             )
 
 

--- a/conda_forge_admin_requests/__main__.py
+++ b/conda_forge_admin_requests/__main__.py
@@ -93,23 +93,28 @@ def run():
                 )
             else:
                 # How old is this failing file? Raise issue after 6h
-                added_at = datetime.fromisoformat(
-                    subprocess.check_output(
-                        [
-                            "git",
-                            "log",
-                            "--diff-filter=A",
-                            "-1",
-                            "--format=%aI",
-                            "--",
-                            filename,
-                        ],
-                        text=True,
-                    ).strip()
-                )
-                # Keep the timedelta value aligned with the issue message in `main.yml`
-                if datetime.now(tz=timezone.utc) - added_at > timedelta(hours=6):
-                    failing_filenames_to_raise.append(filename)
+                added_at = subprocess.check_output(
+                    [
+                        "git",
+                        "log",
+                        "--diff-filter=A",
+                        "-1",
+                        "--format=%aI",
+                        "--",
+                        filename,
+                    ],
+                    text=True,
+                ).strip()
+                if added_at:
+                    added_at_dt = datetime.fromisoformat(added_at)
+                    if datetime.now(tz=timezone.utc) - added_at_dt > timedelta(hours=6):
+                        failing_filenames_to_raise.append(filename)
+                else:
+                    print(
+                        "::error::No timestamp information for",
+                        filename,
+                        file=sys.stderr,
+                    )
         else:
             subprocess.check_call(["git", "rm", filename])
             subprocess.check_call(


### PR DESCRIPTION
- Closes https://github.com/conda-forge/admin-requests/issues/2117. 
- Two parts to this:
	- First commit stops the chain of empty commits. The cronjob will retry anyway in the next cycle, so no need to re-push with the same contents.
	- 2nd and following commits implement the error reporting. If the failing requests have been there for long enough (>6h), an issue is created for each one if none exists yet.