### PR TITLE
Check request before running, return deepcopied update with failures

### DIFF
--- a/conda_forge_admin_requests/access_control.py
+++ b/conda_forge_admin_requests/access_control.py
@@ -4,6 +4,8 @@ This script will process the `travis` and `cirun` requests.
 Main logic lives in conda-smithy. This is just a wrapper for admin-requests infra.
 """
 
+from __future__ import annotations
+
 import copy
 import os
 import subprocess
@@ -11,7 +13,6 @@ import tempfile
 import textwrap
 import time
 from functools import lru_cache
-from typing import Any, Dict, List
 from unittest import mock
 
 from conda_smithy.github import Github
@@ -41,7 +42,7 @@ VALID_ACTIONS = ("travis", *GHA_PROVIDERS)
 def send_pr_cirun(
     feedstock: str,
     feedstock_dir: str,
-    resources: List[str],
+    resources: list[str],
     pull_request: bool,
 ) -> None:
     """
@@ -50,7 +51,7 @@ def send_pr_cirun(
     Parameters:
     feedstock (str): The name of the feedstock.
     feedstock_dir (str): Path to a git checkout of the feedstock.
-    resources (List[str]): The names of the resources for access control.
+    resources (list[str]): The names of the resources for access control.
     pull_request (bool): Whether to allow Pull Requests.
     """
 
@@ -123,7 +124,7 @@ def send_pr_cirun(
 def _process_request_for_feedstock(
     feedstock: str,
     action: str,
-    resources: List[str] = None,
+    resources: list[str] = None,
     revoke: bool = False,
     pull_request: bool = False,
     send_pr: bool = True,
@@ -133,7 +134,7 @@ def _process_request_for_feedstock(
 
     Parameters:
     feedstock (str): The name of the feedstock.
-    resources (List[str]): The names of the resources for access control.
+    resources (list[str]): The names of the resources for access control.
     revoke (bool): Whether to remove the access control.
     pull_request (bool): Whether to allow PRs for resource.
     """
@@ -284,7 +285,7 @@ def check_if_repo_exists(feedstock_name: str) -> bool:
     return True
 
 
-def check(request: Dict[str, Any]) -> None:
+def check(request: dict[str, str | list[str]]) -> None:
     """Check if the access control requests in both 'grant_access'
     and 'revoke_access' directories are valid."""
     print("Checking access control request")
@@ -308,7 +309,7 @@ def check(request: Dict[str, Any]) -> None:
         assert not request.get("revoke", False)
 
 
-def run(request: Dict[str, Any]) -> Dict[str, Any] | None:
+def run(request: dict[str, object]) -> dict[str, object] | None:
     """
     The main function to process the access control requests. It performs the following steps:
     1. Check if the requests are valid.

--- a/conda_forge_admin_requests/archive_branch.py
+++ b/conda_forge_admin_requests/archive_branch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 
 import requests
@@ -138,7 +140,7 @@ def _unarchive_branch(owner, repo, branch, headers):
     print(f"{repo}: restored branch '{branch}' from tag '{branch}'", flush=True)
 
 
-def run(request):
+def run(request: dict[str, object]) -> dict[str, object] | None:
     check(request)
 
     task = request["action"]

--- a/conda_forge_admin_requests/archive_feedstock.py
+++ b/conda_forge_admin_requests/archive_feedstock.py
@@ -1,4 +1,6 @@
-import subprocess
+from __future__ import annotations
+
+import copy
 
 import requests
 
@@ -39,7 +41,7 @@ def process_repo(repo, task):
     print(f"feedstock {repo} was {target_status}", flush=True)
 
 
-def run(request):
+def run(request: dict[str, object]) -> dict[str, object] | None:
     check(request)
     feedstocks = request["feedstocks"]
     task = request["action"]

--- a/conda_forge_admin_requests/archive_feedstock.py
+++ b/conda_forge_admin_requests/archive_feedstock.py
@@ -40,6 +40,7 @@ def process_repo(repo, task):
 
 
 def run(request):
+    check(request)
     feedstocks = request["feedstocks"]
     task = request["action"]
 
@@ -52,9 +53,11 @@ def run(request):
             pkgs_to_do_again.append(feedstock)
 
     if pkgs_to_do_again:
-        request["feedstocks"] = pkgs_to_do_again
-
-    subprocess.check_call(["git", "show"])
+        request = copy.deepcopy(request)
+        request["packages"] = pkgs_to_do_again
+        return request
+    else:
+        return None
 
 
 def check(request):

--- a/conda_forge_admin_requests/archive_feedstock.py
+++ b/conda_forge_admin_requests/archive_feedstock.py
@@ -56,7 +56,7 @@ def run(request: dict[str, object]) -> dict[str, object] | None:
 
     if pkgs_to_do_again:
         request = copy.deepcopy(request)
-        request["packages"] = pkgs_to_do_again
+        request["feedstocks"] = pkgs_to_do_again
         return request
     else:
         return None

--- a/conda_forge_admin_requests/cfep3_copy.py
+++ b/conda_forge_admin_requests/cfep3_copy.py
@@ -2,11 +2,12 @@
 Copy approved artifacts from an external channel to production conda-forge.
 """
 
+from __future__ import annotations
+
 import copy
 import hmac
 import os
 import subprocess
-from typing import Any, Dict
 
 import requests
 
@@ -44,7 +45,7 @@ def check_one(package: str, sha256: str):
         )
 
 
-def check(request: Dict[str, Any]) -> None:
+def check(request: dict[str, object]) -> None:
     packages = request.get("anaconda_org_packages")
     if not packages or not isinstance(packages[0], dict):
         raise ValueError(
@@ -60,7 +61,7 @@ def check(request: Dict[str, Any]) -> None:
         check_one(item["package"], item["sha256"])
 
 
-def run(request: Dict[str, Any]) -> Dict[str, Any] | None:
+def run(request: dict[str, object]) -> dict[str, object] | None:
     if "PROD_BINSTAR_TOKEN" not in os.environ:
         return copy.deepcopy(request)
 

--- a/conda_forge_admin_requests/feedstock_outputs.py
+++ b/conda_forge_admin_requests/feedstock_outputs.py
@@ -133,7 +133,8 @@ def check(request):
                 )
 
 
-def run(request):
+def run(request: dict[str, object]) -> dict[str, object] | None:
+    check(request)
     action = request["action"]
     assert action == "add_feedstock_output"
 
@@ -159,6 +160,7 @@ def run(request):
             items_to_keep[feedstock] = pkgs_to_keep
 
     if items_to_keep:
+        request = copy.deepcopy(request)
         request["feedstock_to_output_mapping"] = items_to_keep
         return request
     else:

--- a/conda_forge_admin_requests/feedstock_outputs.py
+++ b/conda_forge_admin_requests/feedstock_outputs.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import copy
 import io
 import json
 import os

--- a/conda_forge_admin_requests/mark_broken.py
+++ b/conda_forge_admin_requests/mark_broken.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import os
 import subprocess
@@ -78,6 +80,7 @@ def mark_broken_pkg(pkg, action):
         return True
 
 
+def run(request: dict[str, object]) -> dict[str, object] | None:
     check(request)
 
     if "PROD_BINSTAR_TOKEN" not in os.environ:

--- a/conda_forge_admin_requests/mark_broken.py
+++ b/conda_forge_admin_requests/mark_broken.py
@@ -78,7 +78,8 @@ def mark_broken_pkg(pkg, action):
         return True
 
 
-def run(request):
+    check(request)
+
     if "PROD_BINSTAR_TOKEN" not in os.environ:
         return copy.deepcopy(request)
 

--- a/conda_forge_admin_requests/token_reset.py
+++ b/conda_forge_admin_requests/token_reset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import os
 import subprocess
@@ -155,7 +157,7 @@ def reset_feedstock_token(
         )
 
 
-def run(request):
+def run(request: dict[str, object]) -> dict[str, object] | None:
     check(request)
     write_secrets_to_files()
 


### PR DESCRIPTION
I noticed that some actions are not checking before running, or not returning the updated requests with the failures. In the case of `archive`, it was always returning None, which is considered "success".

2nd commit is just a cleanup.