### PR TITLE
Add rust-std-thumbv7em-none-eabihf output to rust feedstock

### DIFF
--- a/requests/add-rust-std-thumbv7em-none-eabihf.yml
+++ b/requests/add-rust-std-thumbv7em-none-eabihf.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  rust:
+    - rust-std-thumbv7em-none-eabihf


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:
* [x] I want to add a package output to a feedstock:
* [x] Pinged the relevant feedstock team(s)
* [x] Added a small description of why the output is being added.

Registers the new output `rust-std-thumbv7em-none-eabihf` for the `rust` feedstock.

This is a new `rust-std` target (bare-metal Cortex-M `thumbv7em-none-eabihf`,
used for microcontroller firmware) added to the rust-feedstock in
conda-forge/rust-feedstock#298, following the same pattern as the existing
`rust-std-wasm32-unknown-unknown` output. Registration is needed so the
feedstock's output validation passes for this new package name.

ping @conda-forge/rust