### PR TITLE
Request: Add blop-base output to blop-feedstock

### DIFF
--- a/requests/add-blop-base-output.yml
+++ b/requests/add-blop-base-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  blop:
+    - blop-base


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/blop

Adding `blop-base` as a new output for `blop-feedstock`. The recipe is being split so `blop-base` contains the base dependencies and `blop` provides the full `blop[all]` dependency set.