### PR TITLE
NEW: Request GHA runners for numba-cuda-mlir

### DIFF
--- a/requests/numba-cuda-mlir.yml
+++ b/requests/numba-cuda-mlir.yml
@@ -1,0 +1,4 @@
+action: depot
+feedstocks:
+  - numba-cuda-mlir
+revoke: false


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description explaining why access is needed

<!--
For example if you are trying to request access for the `foo` feedstock.

  ping @conda-forge/foo

-->

@conda-forge/cuda-python @conda-forge/numba-cuda-mlir 

We want to build on native ARM runners because maintaining a cross-compiling build-script for LLVM components is complicated.