### PR TITLE
Add imas_composer_plots to output of imas_composer feedstock

### DIFF
--- a/requests/add-plots-to-imas_composer-output.yml
+++ b/requests/add-plots-to-imas_composer-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  imas_composer:
+    - imas_composer_plots


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s):
  * [x] Added a small description of why the output is being added.
  
ping @conda-forge/imas_composer

The addition is needed to release a pyqtgraph App as part of the imas_composer package without affecting the dependencies of the main library. See https://github.com/conda-forge/imas_composer-feedstock/pull/5 for details.

