### PR TITLE
Reset feedstock token for constantly

### DIFF
--- a/requests/constantly-token-reset.yml
+++ b/requests/constantly-token-reset.yml
@@ -1,0 +1,3 @@
+action: token_reset
+feedstocks:
+- constantly


### PR DESCRIPTION
Requests a feedstock token reset for `constantly-feedstock`.

The feedstock is stale (last built 15.1.0, never re-rendered) and its `constantly` output is not registered in feedstock-outputs, so builds fail output validation. Resetting the token lets the feedstock upload again and auto-register its output on the next build.

Related: conda-forge/constantly-feedstock#6 (23.10.4 bump + v1 recipe + adds @killua156 as maintainer).