### PR TITLE
Add constantly output to constantly-feedstock

### DIFF
--- a/requests/add-constantly-output.yml
+++ b/requests/add-constantly-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  constantly:
+    - constantly


### PR DESCRIPTION
Registers the `constantly` package output to `constantly-feedstock` in feedstock-outputs.

The feedstock is stale (never re-rendered; last built 15.1.0) and its `constantly` output was never registered, so builds fail output validation with `"constantly-...conda": false` (outputs/c/o/n/constantly.json is 404). This registers the mapping so the feedstock is allowed to produce `constantly`.

Related: conda-forge/constantly-feedstock#6 (23.10.4 bump + v1 recipe + adds @killua156 as maintainer).