### PR TITLE
add gql output gql-with-httpx2

### DIFF
--- a/requests/add-gql-output-gql-with-httpx2.yml
+++ b/requests/add-gql-output-gql-with-httpx2.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  gql:
+    - gql-with-httpx2


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.


@conda-forge/gql would like to add a new output on https://github.com/conda-forge/gql-feedstock/pull/40 based on `httpx2`, per the [upstream `setup.py`](https://github.com/graphql-python/gql/blob/master/setup.py#L56)