### PR TITLE
Mark langflow/lfx/langflow-sdk 1.10.3 as broken (built from unreleased tag)

### DIFF
--- a/requests/broken-langflow-1.10.3.yml
+++ b/requests/broken-langflow-1.10.3.yml
@@ -1,0 +1,9 @@
+action: broken
+packages:
+- noarch/langflow-1.10.3-pyhc5c1524_0.conda
+- noarch/langflow-1.10.3-pyhaf0af83_1.conda
+- noarch/langflow-base-1.10.3-pyh7de08d0_0.conda
+- noarch/langflow-base-1.10.3-pyhf1e8ddc_1.conda
+- noarch/lfx-1.10.3-pyh3edcccd_0.conda
+- noarch/lfx-1.10.3-pyh62f3024_1.conda
+- noarch/langflow-sdk-0.2.3-pyhc364b38_1.conda


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

This request marks the langflow 1.10.3 artifacts (and the related `lfx` 1.10.3 and `langflow-sdk` 0.2.3 outputs) as broken on the `conda-forge` channel.

The langflow-feedstock autotick bot proposed `v1.10.3` (and I merged by trusting it), which is an upstream **git tag that was never cut as a GitHub Release nor published to PyPI**:

- v1.10.3 is **not** a GitHub Release
- The version is **absent from PyPI**

The newest genuine upstream release is `v1.10.2`, so these 1.10.3 artifacts should never have been shipped.

> **Note:** `langflow-sdk-0.2.2` is intentionally **not** included. It was built from the
> released v1.10.2 source and is legitimate.

### Why mark broken instead of patching the repo data

First of all, I would like to state that the README rightly prefers repo-data patches over marking broken, since patching keeps packages installable and environments reproducible.

However, I think this case is different: 1.10.3 is an **entire version that should never have existed**, built from an unreleased upstream tag - there is no metadata to correct, so a patch has nothing to fix. I think, marking broken is the appropriate action here, and it does not delete the artifacts; only new solves stop picking up a version upstream never shipped.

### Preventing recurrence

In https://github.com/conda-forge/langflow-feedstock/pull/7, the feedstock's version source has been pinned to `githubreleases` and the recipe reverted to 1.10.2, so the bot will no longer pick up unreleased git tags.

### Impact

These are low-download packages used mainly by the maintainers, consistent with the "small number of users" (~100 - I hope its a small enough number) guideline in the admin-requests README for marking artifacts broken.

---

### Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* You can use `pixi run find-name {matchspec}` to get a list of filenames matching given spec.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input - I am one of the maintainers of this package. My co-maintainer also thinks the same - https://github.com/conda-forge/langflow-feedstock/pull/7#issuecomment-5033537856

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
