### PR TITLE
Add outputs to icu-feedstock

### DIFF
--- a/requests/icu.yml
+++ b/requests/icu.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  icu:
+    - icu-static


### PR DESCRIPTION
This is required to build micromamba, since libcurl now depends on libpsl (whose static output was added [last week](https://github.com/conda-forge/libpsl-feedstock/commit/682695e78425de003271ab204adb382a9285fa98) which in turn depends on icu.
