### PR TITLE
Add libastra to astra-toolbox-feedstock outputs

### DIFF
--- a/requests/astra-toolbox.yml
+++ b/requests/astra-toolbox.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  astra-toolbox:
+    - libastra


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
This is to convert a separate [libastra feedstock](https://github.com/conda-forge/libastra-feedstock) into an output of the astra-toolbox feedstock, see https://github.com/conda-forge/astra-toolbox-feedstock/pull/29.