### PR TITLE
Mark ipyrad2 as broken

### DIFF
--- a/requests/ipyrad2.yml
+++ b/requests/ipyrad2.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/ipyrad2-0.1.9-pyhd8ed1ab_0.conda


### PR DESCRIPTION
I am requesting to mark all ipyrad2 assets in conda-forge as broken because its required runtime dependencies are available only from Bioconda. Although installation from conda-forge succeeds, the resulting environment is not functional. I would like to move the package to Bioconda. Please move this artifact to the broken label to prevent new installations while preserving reproducibility.

Following a workflow suggested to me on the [conda-forge zulip ](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/.E2.9C.94.20Package.20needs.20to.20move.20from.20conda-forge.20to.20bioconda/with/611352024), I have requested the [conda-forge/ipyrad2-feedstock](https://github.com/conda-forge/ipyrad2-feedstock) be archived, and it was archived today. Now I am requesting ipyrad2 artifacts be marked as broken, so that I can publish to bioconda. I am the package maintainer, and this is a new package so there are no current users of this package except me.

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* You can use `pixi run find-name {matchspec}` to get a list of filenames matching given spec.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [X] Added a description of the problem with the package in the PR description.
  * [X] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
