### PR TITLE
Archive renamed sagemaker-ray feedstocks

### DIFF
--- a/requests/archive-renamed-sagemaker-ray-feedstocks.yml
+++ b/requests/archive-renamed-sagemaker-ray-feedstocks.yml
@@ -1,0 +1,9 @@
+# Archival requested in:
+#   conda-forge/amzn-sagemaker-ray-feedstock#2
+#   conda-forge/amzn-sagemaker-ray-jupyterlab-extension-feedstock#1
+# Both packages renamed for AWS OSS naming compliance; superseded by
+# toolkit-for-ray-on-sagemaker-ai and extension-ray-jupyterlab-sagemaker-ai.
+action: archive
+feedstocks:
+  - amzn-sagemaker-ray
+  - amzn-sagemaker-ray-jupyterlab-extension


### PR DESCRIPTION
Archives `amzn-sagemaker-ray` and `amzn-sagemaker-ray-jupyterlab-extension`, both renamed for AWS OSS naming compliance. Refs the archival issues: conda-forge/amzn-sagemaker-ray-feedstock#2 and conda-forge/amzn-sagemaker-ray-jupyterlab-extension-feedstock#1. Replacement recipes: conda-forge/staged-recipes#34301 and conda-forge/staged-recipes#34299.