### PR TITLE
add additional outputs to mesalib

### DIFF
--- a/requests/mesalib-outputs.yml
+++ b/requests/mesalib-outputs.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  mesalib:
+    - mesa-kosmickrisp
+    - mesa-lavapipe
+    - mesa-llvmpipe


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [X] Pinged the relevant feedstock team(s)
  * [X] Added a small description of why the output is being added.

@conda-forge/mesalib 
`mesalib` is now a meta-feedstock for three Mesa driver packages (perhaps more in the future): `llvmpipe` (OpenGL software driver), `lavapipe` (Vulkan software driver), `kosmickrisp` (Vulkan -> Metal)

https://github.com/conda-forge/mesalib-feedstock/pull/125