### PR TITLE
add earthlens provider outputs

### DIFF
--- a/requests/add-earthlens-provider-outputs.yml
+++ b/requests/add-earthlens-provider-outputs.yml
@@ -1,0 +1,9 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  earthlens:
+    - earthlens-core
+    - earthlens-atmosphere
+    - earthlens-ocean
+    - earthlens-imagery
+    - earthlens-land
+    - earthlens-hazards


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

earthlens 0.11.0 restructures the project into a uv workspace of separate distributions, so `earthlens-feedstock` now builds six new outputs (core + five thematic providers) in addition to the existing `earthlens` / `earthlens-all`. This registers those six new, unclaimed output names to the `earthlens` feedstock:

- `earthlens-core`
- `earthlens-atmosphere`
- `earthlens-ocean`
- `earthlens-imagery`
- `earthlens-land`
- `earthlens-hazards`

ping @conda-forge/earthlens
https://github.com/conda-forge/earthlens-feedstock/pull/11
