### PR TITLE
ADD: x86_64 emulation for native aarch64

### DIFF
--- a/requests/qemu-execve.yaml
+++ b/requests/qemu-execve.yaml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  qemu-execve:
+    - qemu-execve-x86_64


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
This enables emulation of x86_64 on native aarch64 systems

ping @conda-forge/qemu-execve
https://github.com/conda-forge/qemu-execve-feedstock/pull/33