### PR TITLE
Request toppra-python output added to toppra feedstock

### DIFF
--- a/requests/toppra.yaml
+++ b/requests/toppra.yaml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  toppra:
+    - toppra-python


### PR DESCRIPTION
I'd like to add `toppra-python` to the `toppra` feedstock outputs -- effectively adding Python bindings to an existing C++ based library output.

To be coupled with https://github.com/conda-forge/toppra-feedstock/pull/14

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->
