### PR TITLE
Add `mcp-types` output to `mcp` feedstock

### DIFF
--- a/requests/add-mcp-types-output.yml
+++ b/requests/add-mcp-types-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  mcp:
+    - mcp-types


### PR DESCRIPTION
### Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/mcp

### Reasoning

`mcp` 2.0.0 split its wire-protocol types out into a new, separately-published PyPI distribution, [`mcp-types`](https://pypi.org/project/mcp-types/). `mcp` now depends on at an exact matching version of `mcp-types`.

Both packages are built from sibling sdists by the same upstream project ([modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk)), so `mcp-feedstock`'s recipe was restructured as a multi-output recipe that builds both `mcp` and `mcp-types` together. I preferred this over creating a separate feedstock for `mcp-types` because it is not intended to be used independently of `mcp`, and the two packages are always released in lockstep (AFAIK).

CI on the `mcp` v2.0.0 update PR fails output validation because `mcp-types` isn't yet a registered output of this feedstock:

```
validation results:
{
  "noarch/mcp-2.0.0-pyhd8ed1ab_0.conda": true,
  "noarch/mcp-types-2.0.0-pyhd8ed1ab_0.conda": false
}
```

- Feedstock: `mcp` (https://github.com/conda-forge/mcp-feedstock)
- Related PR: https://github.com/conda-forge/mcp-feedstock/pull/52
- `mcp-types` is not currently owned by any other conda-forge feedstock.
