### PR TITLE
Add markitdown-core output to markitdown feedstock

### DIFF
--- a/requests/add-markitdown-core-output.yml
+++ b/requests/add-markitdown-core-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  markitdown:
+    - markitdown-core


### PR DESCRIPTION
Adds the `markitdown-core` output to the `markitdown` feedstock.

`markitdown` is being split into `markitdown-core` (the package with only its mandatory dependencies) and `markitdown` (a metapackage that adds the optional converter backends), so that `conda install markitdown` can convert PDFs and office documents out of the box. Fixes conda-forge/markitdown-feedstock#17.

The build itself is green - both outputs build and all tests pass - and only the output validation step fails because `markitdown-core` is a new name:

```
validation results:
{
  "noarch/markitdown-0.1.7-hd039611_1.conda": true,
  "noarch/markitdown-core-0.1.7-pyhc364b38_1.conda": false
}
```

- feedstock PR: https://github.com/conda-forge/markitdown-feedstock/pull/24
- failing logs: https://github.com/conda-forge/markitdown-feedstock/actions/runs/30538863055/job/90858603904

Requesting the exact output name rather than a glob, since this is a one-off split and not a recurring name change.
