### PR TITLE
Broken aiohttp-session.

### DIFF
--- a/requests/aiohttp-session.yml
+++ b/requests/aiohttp-session.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/aiohttp-session-2.7.0-py_0.tar.bz2


### PR DESCRIPTION
This package is grossly outdated and incompatible with python>3.9. For example,
```
  File "~/.conda/envs/matlab_AP/lib/python3.11/site-packages/aiohttp_session/__init__.py", line 4, in <module>
    from collections import MutableMapping
  ImportError: cannot import name 'MutableMapping' from 'collections' (~/.conda/envs/matlab_AP/lib/python3.11/collections/__init__.py)
```
In modern python, s/collections/collections.abc/. Please upgrade the package.

