### PR TITLE
Add libg2o output to g2o feedstock

### DIFF
--- a/requests/g2o-add-libg2o-output.yml
+++ b/requests/g2o-add-libg2o-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  g2o:
+    - libg2o


### PR DESCRIPTION
The g2o feedstock update in conda-forge/g2o-feedstock#6 splits the installed artifacts into `libg2o` and `g2o` outputs from one staging build. CI builds both packages successfully, but output validation rejects the new `libg2o` package because it is not yet registered for the feedstock.

Failed validation example: https://github.com/conda-forge/g2o-feedstock/actions/runs/30721521682/job/91425992466
