### PR TITLE
Archive fastmdanalysis feedstock

### DIFF
--- a/requests/fastmdanalysis-archive.yml
+++ b/requests/fastmdanalysis-archive.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - fastmdanalysis


### PR DESCRIPTION
Archives the fastmdanalysis feedstock, as requested and explained in conda-forge/fastmdanalysis-feedstock#4.

The project has been renamed and continues as FastMDXplora, currently in review at conda-forge/staged-recipes#34382. No further releases of fastmdanalysis are planned. The existing 1.1.0 package should remain available so existing environments keep working.
