### PR TITLE
Add nanoarrow-outputs.yml for feedstock output

### DIFF
--- a/requests/nanoarrow-outputs.yml
+++ b/requests/nanoarrow-outputs.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # this entry adds a package name
+  nanoarrow:
+    - libnanoarrow
+    - nanoarrow


### PR DESCRIPTION
I'd like to add a "libnanoarrow" output to the "nanoarrow" feedstock, which until this point has only been for the Python package. I hope this request was done properly 😬 . The PR I'm working on is https://github.com/conda-forge/nanoarrow-feedstock/pull/13

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/nanoarrow

