### PR TITLE
Archive 7za-feedstock

### DIFF
--- a/requests/7za.yml
+++ b/requests/7za.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - 7za


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to archive a feedstock:
  * [X] Pinged the team for that feedstock for their input.
  * [X] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [X] Linked that issue in this PR description.
  * [X] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to archive a `foo` feedstock.

  ping @conda-forge/foo

-->

cc @conda-forge/7za: https://github.com/conda-forge/7za-feedstock/issues/3

Ran into this because cmake depends on 7za, but could do with just 7zip, and both need a win-arm64 migration.

xref https://github.com/conda-forge/7zip-feedstock/issues/1