### PR TITLE
Add rust feedstock linux-riscv64 output

### DIFF
--- a/requests/add-rust-std-riscv64gc.yml
+++ b/requests/add-rust-std-riscv64gc.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  rust:
+    - rust-std-riscv64gc-unknown-linux-gnu

--- a/requests/add-rust-std-riscv64gc.yml
+++ b/requests/add-rust-std-riscv64gc.yml
@@ -2,3 +2,4 @@ action: add_feedstock_output
 feedstock_to_output_mapping:
   rust:
     - rust-std-riscv64gc-unknown-linux-gnu
+    - rust-std-riscv64a23-unknown-linux-gnu


### PR DESCRIPTION
Relates to https://github.com/conda-forge/rust-feedstock/pull/297
