### PR TITLE
Exclude deprecated v0 example from feedstock creation

### DIFF
--- a/.github/workflows/create_feedstocks.yml
+++ b/.github/workflows/create_feedstocks.yml
@@ -58,7 +58,7 @@ jobs:
           # Avoid wasting CI time if there are no recipes ready for conversion
           # Checks for both `meta.yaml` and `recipe.yaml` files in the recipes directory
           # Excludes the example recipe(s)
-          if [ "$(ls recipes/*/meta.yaml recipes/*/recipe.yaml 2>/dev/null | grep -vE 'recipes/example/meta.yaml|recipes/example/recipe.yaml' --count)" -eq 0 ]; then
+          if [ "$(ls recipes/*/meta.yaml recipes/*/recipe.yaml 2>/dev/null | grep -vE '^recipes/(example|example-v0-deprecated|example-v1)/(meta|recipe)\.yaml$' --count)" -eq 0 ]; then
             echo "No new recipes found, exiting..."
             exit 0
           fi

--- a/scripts/create_feedstocks.py
+++ b/scripts/create_feedstocks.py
@@ -102,7 +102,12 @@ def list_recipes() -> Iterator[tuple[str, str]]:
         # to be helpful.
         # .DS_Store is created by macOS to store custom attributes of its
         # containing folder.
-        if recipe_dir.name in ["example", "example-v1", ".DS_Store"]:
+        if recipe_dir.name in [
+            "example",
+            "example-v0-deprecated",
+            "example-v1",
+            ".DS_Store",
+        ]:
             continue
 
         # Try to look for a conda-build recipe.


### PR DESCRIPTION
The staged-recipes v0 example was renamed from `example` to `example-v0-deprecated` in conda-forge/staged-recipes#34433. The feedstock creation automation still excluded only the old directory name, so it treated the renamed example as a real recipe and removed it in conda-forge/staged-recipes@b0fa2bf91bde1d6262bf957946b49069715a7d0e.

This adds the renamed directory to `list_recipes()`' skip list and updates the workflow's early-exit filter to consistently exclude both current examples (while retaining the old `example` exclusion). Once merged, we can safely restore `recipes/example-v0-deprecated/meta.yaml` in staged-recipes without it being processed and deleted again.

Validated with pre-commit and a shell check covering example-only and real-recipe file lists.