### PR TITLE
Archive `dry-attr` feedstock as duplicate of `python-attr`

### DIFF
--- a/requests/archive-dry-attr.yml
+++ b/requests/archive-dry-attr.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - dry-attr


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to archive a `foo` feedstock.

  ping @conda-forge/foo

-->
Archive [`dry-attr`](https://github.com/conda-forge/dry-attr-feedstock/) as a duplicate of [`python-attr`](https://github.com/conda-forge/python-attr-feedstock/). Neither of the packages seem to be used by anything, so let's archive the one that was uploaded later (and hass less "obvious" name).

See https://github.com/conda-forge/dry-attr-feedstock/issues/3.

ping @conda-forge/dry-attr 
cc @conda-forge/python-attr 