### PR TITLE
add cleopatra-science-colors output

### DIFF
--- a/requests/add-cleopatra-output-cleopatra-science-colors.yml
+++ b/requests/add-cleopatra-output-cleopatra-science-colors.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  cleopatra:
+    - cleopatra-science-colors


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

This PR registers `cleopatra-science-colors` as an additional output of the existing `cleopatra-feedstock`. `cleopatra-science-colors` is a metapackage matching the new `pip install "cleopatra[science-colors]"` extra (cmap>=0.7.2) used to resolve namespaced scientific colormaps (cmocean:*, cmasher:*, ...). The multi-output recipe change is on an open feedstock PR; it will fail `validate_recipe_outputs` until this mapping is registered.

Feedstock: https://github.com/conda-forge/cleopatra-feedstock
Feedstock PR: https://github.com/conda-forge/cleopatra-feedstock/pull/35

ping @conda-forge/cleopatra