### PR TITLE
Add rust-activation feedstock linux-riscv64 output

### DIFF
--- a/requests/add-rust-activation-linux-riscv64.yml
+++ b/requests/add-rust-activation-linux-riscv64.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  rust-activation:
+    - rust_linux-riscv64


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->

Necessary for https://github.com/conda-forge/rust-activation-feedstock/pull/104.

ping @isuruf @pkgw @xhochy
