### PR TITLE
Archive ninja-python feedstock

### DIFF
--- a/requests/archive-ninja-python.yml
+++ b/requests/archive-ninja-python.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - ninja-python


### PR DESCRIPTION
* Archive https://github.com/conda-forge/ninja-python-feedstock as it never should have been created in the first place. This was my fault for approving https://github.com/conda-forge/staged-recipes/pull/33586.
c.f.
   - https://github.com/conda-forge/staged-recipes/pull/33586#issuecomment-5276526510
   - https://github.com/conda-forge/staged-recipes/pull/19098
   - https://github.com/conda-forge/staged-recipes/pull/31325

A follow up PR (https://github.com/conda-forge/admin-requests/pull/2263) will also mark `ninja-python` as broken to keep it from being used accidentally.

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
   - @conda-forge/ninja-python
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
   - c.f. https://github.com/conda-forge/ninja-python-feedstock/issues/4
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

<!--
For example if you are trying to archive a `foo` feedstock.

  ping @conda-forge/foo

-->
