### PR TITLE
Archive amica-feedstock

### DIFF
--- a/requests/archive-amica.yml
+++ b/requests/archive-amica.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - amica


### PR DESCRIPTION
## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

ping @conda-forge/amica

______

Archives `amica-feedstock`, which has been deprecated by a rename. I am its sole recipe maintainer.

- Issue explaining the archival: conda-forge/amica-feedstock#2
- Replacement recipe: conda-forge/staged-recipes#34517
- Final release PR, closed rather than merged: conda-forge/amica-feedstock#1

Upstream renamed the distribution and import module from `amica` to `jamica` at 0.2.0. The rename resolves a namespace collision: the name `amica` installed a top-level `amica` module, and so does [`amica-python`](https://anaconda.org/conda-forge/amica-python), an independent implementation of the same algorithm by a different author, so the two clobbered each other. Under the `jamica` module name they share no paths and can be co-installed.

This request is opened ahead of the replacement merging, at the reviewer's request on conda-forge/staged-recipes#34517, so that no abandoned feedstock is left behind.

Sorry about the missing checklist — this PR was opened through the CLI, which skipped the template entirely rather than anything being deleted from it.
