### PR TITLE
Add lfx-duckduckgo, lfx-arxiv, lfx-docling, lfx-ibm outputs to langflow feedstock

### DIFF
--- a/requests/langflow-feedstock-output.yml
+++ b/requests/langflow-feedstock-output.yml
@@ -1,0 +1,7 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  langflow:
+    - lfx-duckduckgo
+    - lfx-arxiv
+    - lfx-docling
+    - lfx-ibm


### PR DESCRIPTION
As expected, conda-forge/langflow-feedstock#11 fails output validation because the `lfx-duckduckgo`, `lfx-arxiv`, `lfx-docling`, and `lfx-ibm` outputs are not yet registered for the `langflow` feedstock:

```
validation results:
  {
    "noarch/lfx-duckduckgo-0.1.2-pyh47541eb_0.conda": false,
    "noarch/lfx-arxiv-0.1.2-pyh47541eb_0.conda": false,
    "noarch/langflow-base-1.11.3-pyh47541eb_0.conda": true,
    "noarch/lfx-docling-0.1.3-pyh47541eb_0.conda": false,
    "noarch/lfx-1.11.3-pyh9ad99b9_0.conda": true,
    "noarch/langflow-sdk-0.3.3-pyhc364b38_0.conda": true,
    "noarch/langflow-1.11.3-pyhb4bb6b6_0.conda": true,
    "noarch/lfx-ibm-0.1.2-pyh47541eb_0.conda": false
  }
```

@rxm7706 the only other maintainer of the `langflow` feedstock has already approved the addition of these outputs (refer https://github.com/conda-forge/langflow-feedstock/pull/11#issuecomment-5285795232)

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.
