### PR TITLE
Add libtritonclient output to tritonclient-split

### DIFF
--- a/requests/add-libtritonclient-to-tritonclient-split.yml
+++ b/requests/add-libtritonclient-to-tritonclient-split.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  tritonclient-split:
+    - libtritonclient


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team: @conda-forge/tritonclient-split
  * [x] Added a small description of why the output is being added.

Adds the `libtritonclient` output to `tritonclient-split`. The feedstock recipe is being extended to build Triton's C++ HTTP and gRPC client libraries alongside its existing Python outputs.
