### PR TITLE
Archive pymc3-feedstock

### DIFF
--- a/requests/pymc3-archive.yml
+++ b/requests/pymc3-archive.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - pymc3


### PR DESCRIPTION
Archives `conda-forge/pymc3-feedstock`.

PyMC3 has been superseded by PyMC, which is packaged by
[conda-forge/pymc-feedstock](https://github.com/conda-forge/pymc-feedstock).
The pymc3 feedstock has had no successful updates in years and its open
issues/PRs are all stale, so it no longer serves a purpose.

Discussion and maintainer agreement: conda-forge/pymc3-feedstock#87

🤖 Generated with [Claude Code](https://claude.com/claude-code)