### PR TITLE
Reset esi-core feedstock token

### DIFF
--- a/requests/esi-core-token-reset.yml
+++ b/requests/esi-core-token-reset.yml
@@ -1,0 +1,8 @@
+action: token_reset
+feedstocks:
+- esi-core
+# do not use this unless you have special requirements for your feedstock
+# can be a list with azure, travis, circle, drone, appveyor, github_actions
+# skip_providers: []
+# we can expire tokens earlier if desired - default is null which is immediately
+# existing_tokens_time_to_expiration: null  # set to an int in seconds to use


### PR DESCRIPTION
Requesting a feedstock token reset for esi-core.

Local output validation fails for the existing esi-core output even after rerendering the feedstock. conda_forge_output_validation: true is already enabled.

The package build succeeds, but validation reports:

validation results:
{
  "osx-arm64/esi-core-1.2.9-py312hb0d5321_0.conda": false,
  "osx-arm64/esi-core-1.2.8-py312h9aaab3e_1.conda": false
}

Since both the previous and current versions are rejected, this appears to be a feedstock token/output authorization issue rather than a new-output registration issue.
