### PR TITLE
Request to archive gazebo-yarp-plugins

### DIFF
--- a/requests/gazebo-yarp-plugins-archive.yml
+++ b/requests/gazebo-yarp-plugins-archive.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - gazebo-yarp-plugins


### PR DESCRIPTION
Feedstock discussion and motivation: https://github.com/conda-forge/gazebo-yarp-plugins-feedstock/issues/67, extract from it:

> gazebo-yarp-plugins (https://github.com/robotology/gazebo-yarp-plugins) is not maintained anymore upstream, any interested users should migrate to https://github.com/robotology/gz-sim-yarp-plugins / https://github.com/conda-forge/gazebo-yarp-plugins-feedstock . 



## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

ping @conda-forge/gazebo-yarp-plugins (that is actually just me)


