### PR TITLE
Add albumentationsx subpackages mapping

### DIFF
--- a/requests/add_albumentationsx_subpackages.yml
+++ b/requests/add_albumentationsx_subpackages.yml
@@ -1,0 +1,3 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  albumentationsx: "albumentationsx-*"

--- a/requests/add_albumentationsx_subpackages.yml
+++ b/requests/add_albumentationsx_subpackages.yml
@@ -1,3 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
-  albumentationsx: "albumentationsx-*"
+  albumentationsx:
+    - "albumentationsx-*"


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s) @conda-forge/albumentationsx 
  * [x] Added a small description of why the output is being added.

Enable all `albumentationsx-*` subpackages that will match PyPI's extras (and awaiting the CEP to propagate for a cleaner implementation).