### PR TITLE
Add newton subpackages to feedstock output mapping

### DIFF
--- a/requests/add_newton_subpackages.yml
+++ b/requests/add_newton_subpackages.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  newton:
+    - "newton-*"


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s) @conda-forge/newton 
  * [x] Added a small description of why the output is being added.

Enable all `newton-*` subpackages that will match PyPI's extras (and awaiting the CEP to propagate for a cleaner implementation).