### PR TITLE
add httpx2 output httpcore2

### DIFF
--- a/requests/add-httpx2-output-httpcore2.yml
+++ b/requests/add-httpx2-output-httpcore2.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  httpx2:
+    - httpcore2


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

Per https://github.com/conda-forge/httpx2-feedstock/issues/23 (and https://github.com/conda-forge/httpx2-feedstock/pull/24), @conda-forge/httpx2 and @conda-forge/httpcore2 can be merged, as they are both cut from the same tag, and will always be released on PyPI in lockstep with the same version. This will avoid some PR/CDN races.

Once a release goes out, we can archive `httpcore2-feedstock`