### PR TITLE
Mark mislabeled MontePy beta releases as broken. 

### DIFF
--- a/broken/montepy.txt
+++ b/broken/montepy.txt
@@ -1,3 +1,5 @@
 noarch/montepy-1.6.0b1-pyhd8ed1ab_0.conda
 noarch/montepy-1.6.0b1-pyhd8ed1ab_1.conda
+noarch/montepy-1.6.0b1-pyh6278ad3_2.conda
+
 

--- a/broken/montepy.txt
+++ b/broken/montepy.txt
@@ -1,0 +1,3 @@
+noarch/montepy-1.6.0b1-pyhd8ed1ab_0.conda
+noarch/montepy-1.6.0b1-pyhd8ed1ab_1.conda
+

--- a/broken/montepy.txt
+++ b/broken/montepy.txt
@@ -1,5 +1,0 @@
-noarch/montepy-1.6.0b1-pyhd8ed1ab_0.conda
-noarch/montepy-1.6.0b1-pyhd8ed1ab_1.conda
-noarch/montepy-1.6.0b1-pyh6278ad3_2.conda
-
-

--- a/requests/montepy.yml
+++ b/requests/montepy.yml
@@ -1,0 +1,5 @@
+action: broken
+packages:
+  - noarch/montepy-1.6.0b1-pyhd8ed1ab_0.conda
+  - noarch/montepy-1.6.0b1-pyhd8ed1ab_1.conda
+  - noarch/montepy-1.6.0b1-pyh6278ad3_2.conda


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

# Description

I am the maintainer for the [montepy-feedstock](https://github.com/conda-forge/montepy-feedstock). MontePy is a niche package for the Nuclear Engineering community, and has less than 100 downloads a month. I was trying to create a beta release today. However, I was unable to update the label properly to avoid releasing these to the `main` label, which is undesirable. While I troubleshoot. This may be better as a repodata-patch, but it was unclear to me how to change the labels through this process. I think for now marking these packages as broken will be the safest.

The "failed" deployments:
* https://github.com/conda-forge/montepy-feedstock/pull/20
* https://github.com/conda-forge/montepy-feedstock/pull/21
* https://github.com/conda-forge/montepy-feedstock/pull/22

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* You can use `pixi run find-filenames {matchspec}` to get a list of filenames matching given spec.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input. (I am the sole feedstock maintainer). 

  ping @conda-forge/montepy

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->
