### PR TITLE
Add sqlglotc output to sqlglot feedstock

### DIFF
--- a/requests/sqlglot-sqlglotc-output.yml
+++ b/requests/sqlglot-sqlglotc-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  sqlglot:
+    - sqlglotc


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

cc: @conda-forge/sqlglot @timkpaine @thewchan @tobymao

Please note [this comment by @timkpaine](https://github.com/conda-forge/sqlglot-feedstock/pull/580#issuecomment-5119963537) and [this comment by @thewchan](https://github.com/conda-forge/sqlglot-feedstock/pull/580#issuecomment-5318241788).

The `sqlglot` feedstock now builds and uploads a `sqlglotc` output (a platform-specific compiled/Cython component alongside the `noarch` `sqlglot` package), but this output is not yet registered for the feedstock. As a result, [CI is failing output validation across all platforms (linux-64, osx-64, osx-arm64, win-64)](https://github.com/conda-forge/sqlglot-feedstock/pull/580/checks?check_run_id=96042549838) for every supported Python version, e.g.:

```
"linux-64/sqlglotc-30.17.0-py312h89dfda2_0.conda": false
```

This PR registers `sqlglotc` as an allowed output of the `sqlglot` feedstock so these builds can be uploaded successfully.