### PR TITLE
Mark tempo2 2026.04.1 osx-arm64 build `1` as broken

### DIFF
--- a/requests/tempo2.yml
+++ b/requests/tempo2.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+  - osx-arm64/tempo2-2026.04.1-h6d6ee58_1.conda


### PR DESCRIPTION
The `osx-arm64` build silently loses numerical precision because it was built with Apple Clang, where `long double` has only double precision.

Details and the proposed fix are documented in conda-forge/tempo2-feedstock#48.

This build should not be installed or used for timing analysis.

- [x] Added a description of the problem.
- [x] Pinged the package team.