### PR TITLE
add libpetsird output

### DIFF
--- a/requests/add-libpetsird.yml
+++ b/requests/add-libpetsird.yml
@@ -1,5 +1,4 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
   petsird:
-    - libpetsird_linux-64
-    - libpetsird_osx-arm64
+    - libpetsird

--- a/requests/add-libpetsird.yml
+++ b/requests/add-libpetsird.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  petsird:
+    - libpetsird_linux-64
+    - libpetsird_osx-arm64


### PR DESCRIPTION
* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added

Would like `petsird-feedstock` to produce:

- `noarch/petsird-*py*.conda` (currently works without this PR)
- `osx-arm64/libpetsird-*.conda`
- `linux-64/libpetsird-*.conda`

and in future also:

- `win-64/libpetsird-*.conda`

vis. https://github.com/conda-forge/petsird-feedstock/pull/16
/CC @conda-forge/petsird