### PR TITLE
Add geant4-examples and geant4-qt-mutex outputs to the geant4 feedstock

### DIFF
--- a/requests/geant4-outputs.yml
+++ b/requests/geant4-outputs.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  geant4:
+    - geant4-examples
+    - geant4-qt-mutex


### PR DESCRIPTION
The geant4 feedstock has been converted to a v1 recipe that splits the example sources into geant4-examples and adds a geant4-qt-mutex metapackage to arbitrate between the Qt and Qt-less builds. Output validation currently rejects both.

## Template selection

Please go to the "Preview" tab and select the appropriate template:

* [I want to mark a package as broken (or not broken)](?expand=1&template=broken.md)
* [I want to archive a feedstock](?expand=1&template=archive.md)
* [I want to request (or revoke) access to an opt-in CI resource](?expand=1&template=ci-resource.md)
* [I want to copy an artifact following CFEP-3](?expand=1&template=cfep-3.md)
* [I want to add a package output to a feedstock](?expand=1&template=add-feedstock-output.md)
