### PR TITLE
add py-maidr outputs: py-maidr-with-shiny and py-maidr-with-streamlit

### DIFF
--- a/requests/add-py-maidr-outputs-shiny-streamlit.yml
+++ b/requests/add-py-maidr-outputs-shiny-streamlit.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  py-maidr:
+    - py-maidr-with-shiny
+    - py-maidr-with-streamlit


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

Over on @conda-forge/py-maidr,  https://github.com/conda-forge/py-maidr-feedstock/pull/19 adds two new outputs based on the upstream `pyproject.toml` extras with relatively tight pins that get excited by the test suite.