### PR TITLE
Add r-rfastloess and libfastloess outputs to fastloess feedstock

### DIFF
--- a/requests/add-fastloess-outputs.yml
+++ b/requests/add-fastloess-outputs.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  fastloess:
+    - r-rfastloess
+    - libfastloess


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/fastloess

`fastloess-feedstock` currently only publishes the `fastloess` Python package. We're extending its recipe to a multi-output rattler-build recipe that also builds:

- `r-rfastloess` — an R binding (extendr) for the same upstream `loess-project` Rust crates
- `libfastloess` — a native C++ library binding

Both outputs already build and pass their tests successfully in CI (see https://github.com/conda-forge/fastloess-feedstock/pull/2), but uploads are blocked by output validation since these package names have never been registered for this feedstock before.