### PR TITLE
archive httpcore2-feedstock

### DIFF
--- a/requests/archive-httpcore2-feedstock.yml
+++ b/requests/archive-httpcore2-feedstock.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - httpcore2


### PR DESCRIPTION

## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

Per https://github.com/conda-forge/httpcore2-feedstock/issues/19 (and originally https://github.com/conda-forge/httpx2-feedstock/pull/24 and https://github.com/conda-forge/httpx2-feedstock/issues/23), @conda-forge/httpcore2 can now be archived to reduce PR races.