### PR TITLE
more clang+riscv outputs

### DIFF
--- a/requests/clang.yml
+++ b/requests/clang.yml
@@ -1,0 +1,11 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  cctools-and-ld64:
+    - cctools_impl_linux-riscv64
+    - cctools_linux-riscv64
+    - ld64_linux-riscv64
+  clang-compiler-activation:
+    - clang_linux-riscv64
+    - clangxx_linux-riscv64
+    - clang_impl_linux-riscv64
+    - clangxx_impl_linux-riscv64


### PR DESCRIPTION
Follow-up to #2294, for https://github.com/conda-forge/cctools-and-ld64-feedstock/pull/109 and the matching activation PR.