### PR TITLE
clang for riscv, part 3

### DIFF
--- a/requests/clang.yml
+++ b/requests/clang.yml
@@ -1,0 +1,7 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  ctng-compiler-activation:
+    - clang_linux-riscv64
+    - clangxx_linux-riscv64
+    - clang_impl_linux-riscv64
+    - clangxx_impl_linux-riscv64


### PR DESCRIPTION
Another follow-up to #2294 & #2295, this time for https://github.com/conda-forge/ctng-compiler-activation-feedstock/pull/203