### PR TITLE
Archive feedstocks for 6 deleted apache-airflow providers

### DIFF
--- a/requests/archive-deleted-apache-airflow-providers.yml
+++ b/requests/archive-deleted-apache-airflow-providers.yml
@@ -1,0 +1,8 @@
+action: archive
+feedstocks:
+  - apache-airflow-providers-apache-sqoop
+  - apache-airflow-providers-daskexecutor
+  - apache-airflow-providers-jira
+  - apache-airflow-providers-plexus
+  - apache-airflow-providers-qubole
+  - apache-airflow-providers-tabular


### PR DESCRIPTION
## Checklist:

  * [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

## Context

These 6 Apache Airflow providers have been deleted upstream. None of them appear in the providers directory of the latest Airflow release, [3.3.1](https://github.com/apache/airflow/tree/3.3.1/providers), so no further releases of these packages will ever be made and the feedstocks can be archived.

## Feedstocks and issues

| Feedstock | Issue |
| --- | --- |
| [apache-airflow-providers-apache-sqoop](https://github.com/conda-forge/apache-airflow-providers-apache-sqoop-feedstock) | conda-forge/apache-airflow-providers-apache-sqoop-feedstock#18 |
| [apache-airflow-providers-daskexecutor](https://github.com/conda-forge/apache-airflow-providers-daskexecutor-feedstock) | conda-forge/apache-airflow-providers-daskexecutor-feedstock#5 |
| [apache-airflow-providers-jira](https://github.com/conda-forge/apache-airflow-providers-jira-feedstock) | conda-forge/apache-airflow-providers-jira-feedstock#12 |
| [apache-airflow-providers-plexus](https://github.com/conda-forge/apache-airflow-providers-plexus-feedstock) | conda-forge/apache-airflow-providers-plexus-feedstock#15 |
| [apache-airflow-providers-qubole](https://github.com/conda-forge/apache-airflow-providers-qubole-feedstock) | conda-forge/apache-airflow-providers-qubole-feedstock#19 |
| [apache-airflow-providers-tabular](https://github.com/conda-forge/apache-airflow-providers-tabular-feedstock) | conda-forge/apache-airflow-providers-tabular-feedstock#9 |

## Pings

ping @conda-forge/apache-airflow-providers-apache-sqoop
ping @conda-forge/apache-airflow-providers-daskexecutor
ping @conda-forge/apache-airflow-providers-jira
ping @conda-forge/apache-airflow-providers-plexus
ping @conda-forge/apache-airflow-providers-qubole
ping @conda-forge/apache-airflow-providers-tabular
