### PR TITLE
Add split mesa driver outputs to mesalib-feedstock

### DIFF
--- a/requests/add-mesalib-driver-outputs.yml
+++ b/requests/add-mesalib-driver-outputs.yml
@@ -21,4 +21,3 @@ feedstock_to_output_mapping:
     - mesa-venus
     - mesa-virgl
     - mesa-zink
-    - mesa-kosmickrisp

--- a/requests/add-mesalib-driver-outputs.yml
+++ b/requests/add-mesalib-driver-outputs.yml
@@ -1,0 +1,28 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # mesalib now splits each hardware driver into its own output, see
+  # https://github.com/conda-forge/mesalib-feedstock/pull/150
+  # The names below are the outputs reported as `false` (not allowed) by the
+  # output validation step of that PR's CI.
+  mesalib:
+    - mesa-anv
+    - mesa-crocus
+    - mesa-d3d12
+    - mesa-dzn
+    - mesa-hasvk
+    - mesa-i915
+    - mesa-intel
+    - mesa-iris
+    - mesa-libgallium
+    - mesa-nouveau
+    - mesa-r300
+    - mesa-r600
+    - mesa-svga
+    - mesa-venus
+    - mesa-virgl
+    - mesa-zink
+    # osx-arm64 only (Vulkan on Metal). The osx builds of the PR failed to
+    # solve before reaching output validation, so this name does not appear in
+    # the logs, but it is an output of the same recipe and would fail the same
+    # way.
+    - mesa-kosmickrisp

--- a/requests/add-mesalib-driver-outputs.yml
+++ b/requests/add-mesalib-driver-outputs.yml
@@ -21,8 +21,4 @@ feedstock_to_output_mapping:
     - mesa-venus
     - mesa-virgl
     - mesa-zink
-    # osx-arm64 only (Vulkan on Metal). The osx builds of the PR failed to
-    # solve before reaching output validation, so this name does not appear in
-    # the logs, but it is an output of the same recipe and would fail the same
-    # way.
     - mesa-kosmickrisp


### PR DESCRIPTION
conda-forge/mesalib-feedstock#150 splits each hardware driver out of `mesalib` into its own output, so the feedstock now produces package names that were never registered for it.

The output validation step of that PR's CI marks these 16 as `false` (not allowed for `mesalib-feedstock`):

**linux** — 15 names:

- `mesa-anv`
- `mesa-crocus`
- `mesa-d3d12`
- `mesa-hasvk`
- `mesa-i915`
- `mesa-intel`
- `mesa-iris`
- `mesa-libgallium`
- `mesa-nouveau`
- `mesa-r300`
- `mesa-r600`
- `mesa-svga`
- `mesa-venus`
- `mesa-virgl`
- `mesa-zink`

**win** — 1 name, `mesa-dzn` (the D3D12 Vulkan driver, built on Windows only, so it does not appear in the linux logs).

Each of the 16 is a 404 in `conda-forge/feedstock-outputs` and absent from the channel.

Logs: [linux_64_](https://github.com/conda-forge/mesalib-feedstock/actions/runs/32666568670/job/97260763311), [linux_aarch64_](https://github.com/conda-forge/mesalib-feedstock/actions/runs/32666568670/job/97260763320), [linux_ppc64le_](https://github.com/conda-forge/mesalib-feedstock/actions/runs/32666568670/job/97260763371), [win_64_](https://github.com/conda-forge/mesalib-feedstock/actions/runs/32666568670/job/97260763307).

xref: https://github.com/conda-forge/mesalib-feedstock/pull/150

https://claude.ai/code/session_011cAAG8U7QNcYJDELCya3Db

