### PR TITLE
Allow CUDA feedstocks to register target-specific outputs

### DIFF
--- a/requests/add-win-arm64-cuda-outputs.yml
+++ b/requests/add-win-arm64-cuda-outputs.yml
@@ -1,0 +1,14 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  cuda-cccl:
+    - "cuda-cccl_*"
+  cuda-cudart:
+    - "cuda-cudart_*"
+    - "cuda-cudart-dev_*"
+    - "cuda-cudart-static_*"
+  cuda-nvcc:
+    - "cuda-nvcc_*"
+  cuda-nvcc-impl:
+    - "cuda-crt-dev_*"
+    - "cuda-nvcc-dev_*"
+    - "cuda-nvvm-dev_*"

--- a/requests/add-win-arm64-cuda-outputs.yml
+++ b/requests/add-win-arm64-cuda-outputs.yml
@@ -1,14 +1,14 @@
 action: add_feedstock_output
 feedstock_to_output_mapping:
   cuda-cccl:
-    - "cuda-cccl_*"
+    - "cuda-cccl_win-arm64"
   cuda-cudart:
-    - "cuda-cudart_*"
-    - "cuda-cudart-dev_*"
-    - "cuda-cudart-static_*"
+    - "cuda-cudart_win-arm64"
+    - "cuda-cudart-dev_win-arm64"
+    - "cuda-cudart-static_win-arm64"
   cuda-nvcc:
-    - "cuda-nvcc_*"
+    - "cuda-nvcc_win-arm64"
   cuda-nvcc-impl:
-    - "cuda-crt-dev_*"
-    - "cuda-nvcc-dev_*"
-    - "cuda-nvvm-dev_*"
+    - "cuda-crt-dev_win-arm64"
+    - "cuda-nvcc-dev_win-arm64"
+    - "cuda-nvvm-dev_win-arm64"


### PR DESCRIPTION
## Summary
- Add output globs for target-qualified CUDA package names.
- Cover the anticipated Windows on ARM outputs without requiring a separate request for each package version.

## Test plan
- [x] Confirmed the request uses the required feedstock-to-list mapping.
- [x] Confirmed each anticipated Windows on ARM output matches its feedstock's glob.

## Checklist
- [x] I want to add a package output to a feedstock:
  - [x] Pinged the relevant feedstock teams.
  - [x] Added a description of why the outputs are being added.