### PR TITLE
Add go-{no,}cgo_linux-riscv64 to go-activation-feedstock

### DIFF
--- a/requests/go-linux-riscv64.yml
+++ b/requests/go-linux-riscv64.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  go-activation:
+    - go-nocgo_linux-riscv64
+    - go-cgo_linux-riscv64


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s) @conda-forge/go-activation @conda-forge/go 
  * [ ] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->

needed for https://github.com/conda-forge/go-activation-feedstock/pull/110