### PR TITLE
Allow the tomviz-pipeline feedstock to output tomviz-pipeline

### DIFF
--- a/requests/tomviz-pipeline-output.yml
+++ b/requests/tomviz-pipeline-output.yml
@@ -1,0 +1,9 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  # tomviz-pipeline is moving out of the tomviz repository into its own
+  # repo (github.com/openchemistry/tomviz-pipeline) and its own
+  # feedstock. The tomviz feedstock currently owns this output name and
+  # will drop it in its next release; see the staged-recipes submission
+  # for the new feedstock.
+  tomviz-pipeline:
+    - tomviz-pipeline


### PR DESCRIPTION
Depends on

- [x] https://github.com/conda-forge/staged-recipes/pull/34659

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->

`tomviz-pipeline` is moving out of the tomviz repository into its own repo (https://github.com/openchemistry/tomviz-pipeline) and its own feedstock: https://github.com/conda-forge/staged-recipes/pull/34659. This allows the new feedstock to publish the `tomviz-pipeline` output. I maintain the tomviz feedstock, which currently owns this output name and will stop building it in its next release.

ping @conda-forge/tomviz