### PR TITLE
Add Clang Windows ARM64 activation outputs

### DIFF
--- a/requests/clang-win-activation-win-arm64-outputs.yml
+++ b/requests/clang-win-activation-win-arm64-outputs.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  clang-win-activation:
+    - clang_win-arm64
+    - clangxx_win-arm64
+    - clang-cl_win-arm64


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team: @conda-forge/clang-win-activation
  * [x] Added a small description of why the output is being added.

Registers the three explicit Windows ARM64 activation outputs required by [clang-win-activation-feedstock #69](https://github.com/conda-forge/clang-win-activation-feedstock/pull/69). Its native job builds the packages successfully but output validation rejects the new names until they are mapped to the feedstock.