### PR TITLE
allow llvm-openmp-fortran for flang-rt feedstock

### DIFF
--- a/requests/flang-rt.yml
+++ b/requests/flang-rt.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  flang-rt:
+    - llvm-openmp-fortran


### PR DESCRIPTION
This output needs to move from openmp to flang-rt as of v23. See
* https://github.com/conda-forge/openmp-feedstock/pull/220
* https://github.com/conda-forge/flang-rt-feedstock/pull/28