### PR TITLE
mark zeroconf 1.0.0 as broken

### DIFF
--- a/requests/zeroconf-broken.yml
+++ b/requests/zeroconf-broken.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+- noarch/zeroconf-1.0.0-pyhd8ed1ab_0.conda


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Guidelines for marking packages as broken:

* We prefer to patch the repo data (see [here](https://github.com/conda-forge/conda-forge-repodata-patches-feedstock))
  instead of marking packages as broken. This alternative workflow makes environments more reproducible.
* Packages with requirements/metadata that are too strict but otherwise work are
  not technically broken and should not be marked as such.
* Packages with missing metadata can be marked as broken on a temporary basis
  but should be patched in the repo data and be marked unbroken later.
* In some cases where the number of users of a package is small or it is used by
  the maintainers only, we can allow packages to be marked broken more liberally.
* You can use `pixi run find-filenames {matchspec}` to get a list of filenames matching given spec.
* We (`conda-forge/core`) try to make a decision on these requests within 24 hours.

What will happen when a package is marked broken?

* Our bots will add the `broken` label to the package. The `main` label will remain on the package and this is normal.
* Our bots will rebuild our repodata patches to remove this package from the repodata.
* In a few hours after the `anaconda.org` CDN picks up the new patches, you will no longer be able to install the package from the `main` channel.


## Checklist:

* [x] I want to mark a package as broken (or not broken):
  * [x] Added a description of the problem with the package in the PR description.
  * [x] Pinged the team for the package for their input.

<!--
For example if you are trying to mark a `foo` conda package as broken.

  ping @conda-forge/foo

-->

seems like zeroconf 1.0.0 was deleted from pypi:

<img width="1450" height="901" alt="image" src="https://github.com/user-attachments/assets/b2b8b4cf-737e-4bd7-9a80-ec32aef7802a" />

xref https://github.com/conda-forge/zeroconf-feedstock/pull/130#discussion_r3890203248, cc @conda-forge/zeroconf

also, the package is a compiled package disguised as `noarch: python`

```
$ pixi exec rattler fetch-file https://conda.anaconda.org/conda-forge/noarch/zeroconf-1.0.0-pyhd8ed1ab_0.conda site-packages/zeroconf-1.0.0.dist-info/WHEEL
Wheel-Version: 1.0
Generator: poetry-core 2.2.1
Root-Is-Purelib: false
Tag: cp310-cp310-manylinux_2_34_x86_64
```

https://github.com/conda-forge/zeroconf-feedstock/pull/130 fixes it