### PR TITLE
Register the flash-attn-3 feedstock output

### DIFF
--- a/requests/add-flash-attn-3-output.yml
+++ b/requests/add-flash-attn-3-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  flash-attn:
+    - flash-attn-3


### PR DESCRIPTION
## Request

Register `flash-attn-3` as an allowed output of `flash-attn-feedstock`.

## Context

FlashAttention 3 is independently packaged from upstream `hopper/` on the dedicated `v3.x` feedstock branch in https://github.com/conda-forge/flash-attn-feedstock/pull/53. This keeps the current FlashAttention 2 package on `main` and avoids duplicate output ownership with the staged-recipes fallback at https://github.com/conda-forge/staged-recipes/pull/34680.

## Validation

The request uses the exact output name and matches `examples/example-add-feedstock-output.yml`.