### PR TITLE
Add flash-attn to Depot

### DIFF
--- a/requests/flash-attn.yml
+++ b/requests/flash-attn.yml
@@ -1,0 +1,5 @@
+action: depot
+feedstocks:
+  - flash-attn
+# revoke access to the runners
+revoke: false


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description explaining why access is needed

<!--
For example if you are trying to request access for the `foo` feedstock.

  ping @conda-forge/foo

-->
@conda-forge/flash-attn already has access to Blacksmith, but building "natively" on ARM using their runners is significantly slower than x86. I suspect their native runners are not native. Moving this feedstock to Depot because that is the service that libmagma uses. 