### PR TITLE
Add rust-std-wasm32-wasip1-threads to Rust outputs

### DIFF
--- a/requests/rust.yml
+++ b/requests/rust.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  rust:
+    - rust-std-wasm32-wasip1-threads


### PR DESCRIPTION
In support of https://github.com/conda-forge/rust-feedstock/pull/272, context from there:

> Add the [wasm32-wasip1-threads](https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-wasip1-threads.html) target, a tier 2 target (like the other wasm targets). The goal is to make it easier to use with [napi-rs](https://napi.rs/docs/concepts/webassembly), which provides support for both nodejs and similar runtimes, as well as browser (with a polyfill).

Name based on the validation results of [this job](https://github.com/conda-forge/rust-feedstock/actions/runs/33442913742/job/99655224467?pr=272)
```
2026-08-31T22:18:00.5459127Z   "noarch/rust-std-wasm32-wasip1-threads-1.98.0-unix_0.conda": false,
```

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

ping @conda-forge/rust-feedstock