### PR TITLE
Register libpuma and pumapy outputs for the puma feedstock

### DIFF
--- a/requests/puma-outputs.yml
+++ b/requests/puma-outputs.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  puma:
+    - libpuma
+    - pumapy

--- a/requests/puma-outputs.yml
+++ b/requests/puma-outputs.yml
@@ -3,3 +3,5 @@ feedstock_to_output_mapping:
   puma:
     - libpuma
     - pumapy
+    - libpuma-devel
+    - puma-python


### PR DESCRIPTION
The puma feedstock is being migrated to a rattler-build recipe that splits the build into libpuma, pumapy and puma. The puma output is already registered, so only the two new outputs need to be added.

Please see https://github.com/conda-forge/puma-feedstock/issues/30

<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
* [x] Pinged the relevant feedstock team(s)
* [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->

ping @conda-forge/puma-feedstock 
ping @Tobias-Fischer 