### PR TITLE
Add tensorrt to Depot

### DIFF
--- a/requests/tensorrt.yml
+++ b/requests/tensorrt.yml
@@ -1,0 +1,4 @@
+action: depot
+feedstocks:
+  - tensorrt
+revoke: false


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description explaining why access is needed

Large runners are needed to avoid failing Windows uploads. This is an known issue where large (>0.5 GB) conda packages will fail to upload from the default Windows runners.

https://github.com/conda-forge/tensorrt-feedstock/issues/2 https://github.com/conda/infrastructure/issues/1159

ping @conda-forge/tensorrt 