### PR TITLE
Mark amzn-sagemaker-aiops-jupyterlab-extension 1.1.2 as broken

### DIFF
--- a/requests/mark-broken-amzn-sagemaker-aiops-jupyterlab-extension-1.1.2.yml
+++ b/requests/mark-broken-amzn-sagemaker-aiops-jupyterlab-extension-1.1.2.yml
@@ -1,0 +1,3 @@
+action: broken
+packages:
+  - noarch/amzn-sagemaker-aiops-jupyterlab-extension-1.1.2-pyhd8ed1ab_0.conda


### PR DESCRIPTION
The 1.1.2 release of `amzn-sagemaker-aiops-jupyterlab-extension` was published prematurely; the feedstock has been reverted to 1.0.6 (conda-forge/amzn-sagemaker-aiops-jupyterlab-extension-feedstock@57f22b9). The release will go out later as 1.1.3, so this build won't need to be un-broken.
  
  - `noarch/amzn-sagemaker-aiops-jupyterlab-extension-1.1.2-pyhd8ed1ab_0.conda`
  
  I am a maintainer of the feedstock.