### PR TITLE
Add feedstock output mapping for mumps-fortran-abi-devel

### DIFF
--- a/requests/mumps-fortran-abi-devel.yml
+++ b/requests/mumps-fortran-abi-devel.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  mumps:
+    - mumps-seq-devel
+    - mumps-mpi-devel


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->

mumps-seq-devel / mumps-mpi-devel are Fortran ABI marker outputs, needed so Fortran consumers of MUMPS on Windows can select the flang- or ifx-built variant. Same pattern as conda-forge/admin-requests#2134. See https://github.com/conda-forge/flang-activation-feedstock/issues/14 and https://github.com/conda-forge/mumps-feedstock/pull/147

ping @conda-forge/mumps