### PR TITLE
Add prov-core output to prov-feedstock

### DIFF
--- a/requests/2026-09-04-prov-add-prov-core.yml
+++ b/requests/2026-09-04-prov-add-prov-core.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  prov:
+    - prov-core


### PR DESCRIPTION
Registering a new output for `prov-feedstock`: [conda-forge/prov-feedstock#27](https://github.com/conda-forge/prov-feedstock/pull/27) splits the recipe into `prov` (unchanged) and a new minimal `prov-core` output, but the PR's CI build fails output validation since `prov-core` isn't yet an allowed output for the feedstock:

```
validation results:
{
  "noarch/prov-core-3.1.0-pyhd8ed1ab_1.conda": false,
  "noarch/prov-3.1.0-pyha770c72_1.conda": true
}
```

Requesting `prov-core` be added as an allowed output of the `prov` feedstock.