### PR TITLE
Archive chemex feedstock

### DIFF
--- a/requests/chemex-archive.yml
+++ b/requests/chemex-archive.yml
@@ -1,0 +1,3 @@
+action: archive
+feedstocks:
+  - chemex


### PR DESCRIPTION
## Checklist:

* [x] I want to archive a feedstock:
  * [x] Pinged the team for that feedstock for their input.
  * [x] Make sure you have opened an issue on the feedstock explaining why it was archived.
  * [x] Linked that issue in this PR description.
  * [x] Added links to any other relevant issues/PRs in the PR description.

Please archive `chemex-feedstock`, as discussed in https://github.com/conda-forge/chemex-feedstock/issues/56.

ChemEx upstream has standardized on PyPI as its authoritative distribution and recommends `uv tool`. The feedstock packages 2025.4.0 while the current upstream release is 2026.09.0, and its sole recipe maintainer does not intend to continue maintaining this secondary distribution channel. Archival preserves the already-published packages while making the feedstock read-only.

The obsolete automated version PRs were closed without being repaired or merged:

* https://github.com/conda-forge/chemex-feedstock/pull/52
* https://github.com/conda-forge/chemex-feedstock/pull/53
* https://github.com/conda-forge/chemex-feedstock/pull/54
* https://github.com/conda-forge/chemex-feedstock/pull/55
