### PR TITLE
Request `roboplan-core` and `roboplan-common` outputs added to `roboplan-feedstock`

### DIFF
--- a/requests/roboplan.yaml
+++ b/requests/roboplan.yaml
@@ -2,4 +2,5 @@ action: add_feedstock_output
 feedstock_to_output_mapping:
   roboplan:
     - libroboplan-core
+    - roboplan-common
     - roboplan-core-python

--- a/requests/roboplan.yaml
+++ b/requests/roboplan.yaml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  roboplan:
+    - libroboplan-core
+    - roboplan-core-python


### PR DESCRIPTION
Requesting a few more outputs to my feedstock due to an upcoming package renaming.

* New `roboplan-common` package
* `libroboplan` / `roboplan-python` is being renamed to `libroboplan-core` / `roboplan-core-python`
* The existing `roboplan-all` is being replaced as the `roboplan` metapackage

See https://github.com/conda-forge/roboplan-feedstock/pull/22 for more info

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

