### PR TITLE
add hunspell-en output aoo-mozilla-en-dict-gb-oxendict

### DIFF
--- a/requests/add-hunspell-en-output-aoo-mozilla-en-dict-gb-oxendict.yml
+++ b/requests/add-hunspell-en-output-aoo-mozilla-en-dict-gb-oxendict.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  hunspell-en:
+    - aoo-mozilla-en-dict-gb-oxendict


### PR DESCRIPTION
## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.


On https://github.com/conda-forge/hunspell-en-feedstock/pull/23, @conda-forge/hunspell-en adds an output `aoo-mozilla-en-dict-gb-oxendict` for the Oxford English Dictionary.