### PR TITLE
Add pydantic-monty-client and pydantic-monty-runtime outputs to pydantic-monty

### DIFF
--- a/requests/add-pydantic-monty-outputs.yml
+++ b/requests/add-pydantic-monty-outputs.yml
@@ -1,0 +1,5 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  pydantic-monty:
+    - pydantic-monty-client
+    - pydantic-monty-runtime


### PR DESCRIPTION
The `pydantic-monty` feedstock is being restructured into three outputs so that the `monty` binary (python-version independent) and the `pydantic_monty` extension module (built per python version) can be built separately:

- `pydantic-monty-runtime` — the `monty` binary, from the `pydantic-monty-runtime` sdist
- `pydantic-monty-client` — the `pydantic_monty` extension module, from the `pydantic-monty-client` sdist
- `pydantic-monty` — the existing metapackage, already registered to this feedstock

The two new output names are unregistered, so every build job fails output validation:

```
validation results:
{
  "linux-aarch64/pydantic-monty-client-0.0.23-py313h568d67c_2.conda": false
}
```

Neither name exists on conda-forge or in `feedstock-outputs`, and all three come from the same upstream project (https://github.com/pydantic/monty), published to PyPI as `pydantic-monty`, `pydantic-monty-client` and `pydantic-monty-runtime`.

Feedstock PR: https://github.com/conda-forge/pydantic-monty-feedstock/pull/28
Failing job log: https://github.com/conda-forge/pydantic-monty-feedstock/actions/runs/34062228574/job/101564663295