### PR TITLE
Request to add LUE to Blacksmith runners

### DIFF
--- a/requests/lue.yml
+++ b/requests/lue.yml
@@ -1,0 +1,4 @@
+action: blacksmith
+feedstocks:
+  - lue
+revoke: false


### PR DESCRIPTION
## Checklist:

* [x] I want to request (or revoke) access to an opt-in CI resource:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description explaining why access is needed

ping @conda-forge/lue

When preparing LUE releases, we consistently exceed the maximum build time and RAM of the default runners. This is mainly due to the number of source modules that need to be compiled, and the C++ template instantiations that happen during the compilation. Over the past few years we have updated the code in order to decrease the build-times and make compilations of individual modules fit into the available RAM.
The project is actively being worked on and the number of modules still grows, increasing the build times and currently preventing us to release our software as a Conda package. Having access to the Blacksmith runners (for example), will likely allow us to release LUE again.

LUE repository: https://github.com/computationalgeography/lue

Thank you in advance for considering this request.