### PR TITLE
Register binutils win-arm64 outputs

### DIFF
--- a/requests/binutils-win-arm64-outputs.yml
+++ b/requests/binutils-win-arm64-outputs.yml
@@ -1,0 +1,6 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  binutils:
+    - ld_impl_win-arm64
+    - binutils_impl_win-arm64
+    - binutils_win-arm64


### PR DESCRIPTION
## Summary
Register new outputs from [conda-forge/binutils-feedstock#117](https://github.com/conda-forge/binutils-feedstock/pull/117):

- `ld_impl_win-arm64`
- `binutils_impl_win-arm64`
- `binutils_win-arm64`

The linux-64 jobs already build these packages; CI fails output validation until they are allowed for `binutils-feedstock`.