### PR TITLE
Mark perl 5.32.1 build 8 as broken

### DIFF
--- a/requests/perl-5.32.1-build8-broken.yml
+++ b/requests/perl-5.32.1-build8-broken.yml
@@ -1,0 +1,9 @@
+action: broken
+packages:
+- linux-64/perl-5.32.1-8_hb03c661_perl5.conda
+- linux-aarch64/perl-5.32.1-8_he30d5cf_perl5.conda
+- linux-ppc64le/perl-5.32.1-8_hfc7e52b_perl5.conda
+- linux-riscv64/perl-5.32.1-8_h63d4614_perl5.conda
+- osx-64/perl-5.32.1-8_ha1e9b39_perl5.conda
+- osx-arm64/perl-5.32.1-8_h88b7d96_perl5.conda
+- win-64/perl-5.32.1.1-8_h57928b3_strawberry.conda


### PR DESCRIPTION
## Template selection

Please go to the "Preview" tab and select the appropriate template:

* [I want to mark a package as broken (or not broken)](?expand=1&template=broken.md)
* [I want to archive a feedstock](?expand=1&template=archive.md)
* [I want to request (or revoke) access to an opt-in CI resource](?expand=1&template=ci-resource.md)
* [I want to copy an artifact following CFEP-3](?expand=1&template=cfep-3.md)
* [I want to add a package output to a feedstock](?expand=1&template=add-feedstock-output.md)

See https://github.com/conda-forge/perl-feedstock/issues/79
and https://github.com/conda-forge/perl-feedstock/issues/78