### PR TITLE
Add the outputs of the smspp-project feedstock

### DIFF
--- a/requests/smspp-project-outputs.yml
+++ b/requests/smspp-project-outputs.yml
@@ -1,0 +1,38 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  smspp-project:
+    - libsmspp
+    - libsmspp-bds
+    - libsmspp-bkb
+    - libsmspp-bnx
+    - libsmspp-bundle
+    - libsmspp-cflb
+    - libsmspp-frankwolfe
+    - libsmspp-investment
+    - libsmspp-lds
+    - libsmspp-lukfi
+    - libsmspp-mcf
+    - libsmspp-mcfclass
+    - libsmspp-mcflemon
+    - libsmspp-milp
+    - libsmspp-mmcf
+    - libsmspp-mssb
+    - libsmspp-sddp
+    - libsmspp-sfdcr
+    - libsmspp-srs
+    - libsmspp-stochastic
+    - libsmspp-svm
+    - libsmspp-tssb
+    - libsmspp-ucblock
+    - smspp-bkb
+    - smspp-cflb
+    - smspp-investment
+    - smspp-mcf
+    - smspp-mmcf
+    - smspp-mssb
+    - smspp-sddp
+    - smspp-sfdcr
+    - smspp-svm
+    - smspp-tools
+    - smspp-tssb
+    - smspp-ucblock


### PR DESCRIPTION
The smspp-project feedstock is being split into one package per module and per tool, in conda-forge/smspp-project-feedstock#26, so it needs the new output names registered: `libsmspp` and `libsmspp-<module>` for the libraries, `smspp-<module>` and `smspp-tools` for the command-line tools. `smspp-project` stays as the package installing everything, and none of the new names is taken on conda-forge.

cc @conda-forge/smspp-project