### PR TITLE
Add promtool output to the prometheus feedstock

### DIFF
--- a/requests/add-promtool-output.yml
+++ b/requests/add-promtool-output.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  prometheus:
+    - promtool


### PR DESCRIPTION
Registers `promtool` as an allowed output of the `prometheus` feedstock.

conda-forge/prometheus-feedstock#64 updates that feedstock from 2.34.0 to 3.14.0, converts the recipe to the v1 format, and adds `promtool` — the command line utility that ships in every upstream Prometheus release tarball, used to validate configuration and to check and unit-test recording and alerting rules. The feedstock's recipe only ever built `./cmd/prometheus`, so `promtool` has never been packaged.

It is split into its own output rather than bundled with the server: the two have quite different audiences, and `promtool` is commonly wanted on its own to lint rule files in CI without the ~140 MB server binary.

The name `promtool` is not currently used by any conda-forge feedstock.

Both outputs build and pass their tests locally on osx-arm64 with rattler-build.