### PR TITLE
Add filament-filagui-static output to filament

### DIFF
--- a/requests/add-filament-filagui-static.yml
+++ b/requests/add-filament-filagui-static.yml
@@ -1,0 +1,4 @@
+action: add_feedstock_output
+feedstock_to_output_mapping:
+  filament:
+    - filament-filagui-static


### PR DESCRIPTION
<!--
Hi!

Thank you for making an admin request on this repo. We strive to make a decision
on these requests within 24 hours.

Please use the text below to add context about this PR.

Cheers and thank you for contributing to conda-forge!
-->

## Checklist:

* [x] I want to add a package output to a feedstock:
  * [x] Pinged the relevant feedstock team(s)
  * [x] Added a small description of why the output is being added.

<!--
For example if you are trying to add an output to 'foo' feedstock.

  ping @conda-forge/foo

-->

The draft [filament-feedstock PR #10](https://github.com/conda-forge/filament-feedstock/pull/10) adds the optional `filament-filagui-static` output. Registering the exact output name allows its package validation to run while the packaging design remains under review. The separate `-static` output follows [CFEP-18's static-library packaging rule](https://github.com/conda-forge/cfep/blob/main/cfep-18.md#implementation).

ping @conda-forge/filament
